### PR TITLE
Log remaining pods when pending soft delete, metrics for evicted pods

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -24,6 +24,7 @@ These are the metrics that Escalator exposes, and are subject to change:
  - **`escalator_node_group_cordoned_nodes`**: nodes considered by specific node groups that are cordoned
  - **`escalator_node_group_nodes`**: nodes considered by specific node groups
  - **`escalator_node_group_pods`**: pods considered by specific node groups
+ - **`escalator_node_group_pods_evicted`**: pods evicted during a scale down
 
 ### Node Group CPU and Memory
  

--- a/pkg/controller/scale_down.go
+++ b/pkg/controller/scale_down.go
@@ -43,8 +43,16 @@ func (c *Controller) TryRemoveTaintedNodes(opts scaleOpts) (int, error) {
 					toBeDeleted = append(toBeDeleted, candidate)
 				}
 			} else {
-				log.Debugf("node %v not ready for deletion. Hard delete time remaining %v",
+				nodePodsRemaining, ok := k8s.NodePodsRemaining(candidate, opts.nodeGroup.NodeInfoMap)
+				podsRemainingMessage := ""
+				if ok {
+					podsRemainingMessage = fmt.Sprintf("%d pods remaining", nodePodsRemaining)
+				} else {
+					podsRemainingMessage = "unknown number of pods remaining"
+				}
+				log.Debugf("node %v not ready for deletion (%s). Hard delete time remaining %v",
 					candidate.Name,
+					podsRemainingMessage,
 					opts.nodeGroup.Opts.HardDeleteGracePeriodDuration()-now.Sub(*taintedTime),
 				)
 			}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -60,6 +60,15 @@ var (
 		},
 		[]string{"node_group"},
 	)
+	// NodeGroupsPodEvicted pods evicted during a scale down
+	NodeGroupPodsEvicted = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_group_pods_evicted",
+			Namespace: NAMESPACE,
+			Help: "pods evicted during a scale down",
+		},
+		[]string{"node_group"},
+	)
 	// NodeGroupsMemPercent percentage of util of memory
 	NodeGroupsMemPercent = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -194,6 +203,7 @@ func init() {
 	prometheus.MustRegister(NodeGroupNodesUntainted)
 	prometheus.MustRegister(NodeGroupNodesTainted)
 	prometheus.MustRegister(NodeGroupPods)
+	prometheus.MustRegister(NodeGroupPodsEvicted)
 	prometheus.MustRegister(NodeGroupsMemPercent)
 	prometheus.MustRegister(NodeGroupsCPUPercent)
 	prometheus.MustRegister(NodeGroupCPURequest)


### PR DESCRIPTION
When watching pending node scale-downs, it's nice to know how many pods are left on a node to see how "close" it is to being ready for scale down. The first commit adds that number to the log for a node not ready to scale down.

Additionally, it's nice to know if, when we've hard deleted a node, how many pods were running on the node and therefore got forcibly stopped. For our use case, we want to minimize the number of evicted pods while still scaling down aggressively, so it's good to be able to track this metric.

The way I've written the code, the `NodeEmpty` function is no longer strictly necessary, and calling both it and `NodePodsRemaining` results in some duplicate work. It felt like it wasn't a lot of duplicate work, and worth it for cleaner code.

Would love any comments you have on the approach I've taken. Thanks!