### PR TITLE
fix memory request and capacity conversion from a quantity to an int64

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -30,9 +30,9 @@ These are the metrics that Escalator exposes, and are subject to change:
  
  - **`escalator_node_group_mem_percent`**: percentage of util of memory
  - **`escalator_node_group_cpu_percent`**: percentage of util of cpu
- - **`escalator_node_group_mem_request`**: milli value of node request mem
+ - **`escalator_node_group_mem_request`**: byte value of node request mem
  - **`escalator_node_group_cpu_request`**: milli value of node request cpu
- - **`escalator_node_group_mem_capacity`**: milli value of node Capacity mem
+ - **`escalator_node_group_mem_capacity`**: byte value of node capacity mem
  - **`escalator_node_group_cpu_capacity`**: milli value of node capacity cpu
 
 ### Node Group Scaling

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -221,17 +221,8 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	// Metrics
 	metrics.NodeGroupCPURequest.WithLabelValues(nodegroup).Set(float64(cpuRequest.MilliValue()))
 	metrics.NodeGroupCPUCapacity.WithLabelValues(nodegroup).Set(float64(cpuCapacity.MilliValue()))
-
-	bytesMemCap, ok := memCapacity.AsInt64()
-	if !ok {
-		log.Error("unable to get memCapacity as int64")
-	}
-	bytesMemReq, ok := memRequest.AsInt64()
-	if !ok {
-		log.Error("unable to get memRequest as int64")
-	}
-	metrics.NodeGroupMemCapacity.WithLabelValues(nodegroup).Set(float64(bytesMemCap))
-	metrics.NodeGroupMemRequest.WithLabelValues(nodegroup).Set(float64(bytesMemReq))
+	metrics.NodeGroupMemCapacity.WithLabelValues(nodegroup).Set(float64(memCapacity.MilliValue() / 1000))
+	metrics.NodeGroupMemRequest.WithLabelValues(nodegroup).Set(float64(memRequest.MilliValue() / 1000))
 
 	// If we ever get into a state where we have less nodes than the minimum
 	if len(untaintedNodes) < nodeGroup.Opts.MinNodes {

--- a/pkg/k8s/util_test.go
+++ b/pkg/k8s/util_test.go
@@ -21,6 +21,16 @@ func TestPodIsDaemonSet(t *testing.T) {
 	assert.False(t, k8s.PodIsDaemonSet(pod))
 }
 
+func TestPodIsStatic(t *testing.T) {
+	staticPod := test.BuildTestPod(test.PodOpts{})
+	staticPod.ObjectMeta.Annotations = make(map[string]string)
+	staticPod.ObjectMeta.Annotations["kubernetes.io/config.source"] = "file"
+	pod := test.BuildTestPod(test.PodOpts{})
+
+	assert.True(t, k8s.PodIsStatic(staticPod))
+	assert.False(t, k8s.PodIsDaemonSet(pod))
+}
+
 func TestCalculatePodsRequestTotal(t *testing.T) {
 	p1 := test.BuildTestPod(test.PodOpts{
 		CPU: []int64{1000},

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -87,12 +87,12 @@ var (
 		},
 		[]string{"node_group"},
 	)
-	// NodeGroupMemRequest milli value of node request mem
+	// NodeGroupMemRequest byte value of node request mem
 	NodeGroupMemRequest = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "node_group_mem_request",
 			Namespace: NAMESPACE,
-			Help: "milli value of node request mem",
+			Help: "byte value of node request mem",
 		},
 		[]string{"node_group"},
 	)
@@ -105,12 +105,12 @@ var (
 		},
 		[]string{"node_group"},
 	)
-	// NodeGroupMemCapacity milli value of node Capacity mem
+	// NodeGroupMemCapacity byte value of node capacity mem
 	NodeGroupMemCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "node_group_mem_capacity",
 			Namespace: NAMESPACE,
-			Help: "milli value of node Capacity mem",
+			Help: "byte value of node capacity mem",
 		},
 		[]string{"node_group"},
 	)


### PR DESCRIPTION
This fixes the conversion of pod memory request and node memory capacity from a quantity to an int64 for use with metrics. This will allow the handling of millivalues (which are backwards supported in Kubernetes) in the prometheus metrics.

Note: we already handle the percentage usage calculation using millivalues (which is good) so Escalator would have already handled millivalues when calculating utilisation.

I've updated the metric descriptions for `escalator_node_group_mem_request` and `escalator_node_group_cpu_capacity` as well, as they are the number of bytes, **not** a milli value.

This PR also includes a unit test for `k8s. PodIsStatic`.

cc @wendorf 

Fixes #118