### PR TITLE
add support for auto-discovering node group options from the cloud provider

### DIFF
--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -72,6 +72,16 @@ clamp/adjust the scale up amount to create **2** nodes. The new current node cou
 `min_nodes` and `max_nodes` to be larger/smaller than the cloud provider's, the cloud provider may still block the scale
 activity if the activity exceeds the cloud provider's limits.
 
+#### Auto Discovery
+
+`min_nodes` and `max_nodes` can be auto-discovered by Escalator and set to the min and max node values that are
+configured for the node group in the cloud provider. These values are populated only when Escalator starts for the first
+time. If the values in the cloud provider have changed, you will have to stop and restart Escalator for it to pick up
+the new values.
+
+To enable this, set `min_nodes` and `max_nodes` to `0` for the node group in `nodegroups_config.yaml` or simply remove
+the two options from `nodegroups_config.yaml`.
+
 ### `dry_mode`
 
 This flag allows running a specific node group in dry mode. This will ensure Escalator doesn't taint, cordon or modify

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -83,6 +83,15 @@ func NewController(opts Opts, stopChan <-chan struct{}) *Controller {
 		if !ok {
 			log.Fatalf("could not find node group \"%v\" on cloud provider", nodeGroupOpts.CloudProviderGroupName)
 		}
+
+		// Set the node group min_nodes and max_nodes options based on the values in the cloud provider
+		if nodeGroupOpts.autoDiscoverMinMaxNodeOptions() {
+			nodeGroupOpts.MinNodes = int(cloudProviderNodeGroup.MinSize())
+			log.Debugf("auto discovered min_nodes = %v for node group %v", nodeGroupOpts.MinNodes, nodeGroupOpts.Name)
+			nodeGroupOpts.MaxNodes = int(cloudProviderNodeGroup.MaxSize())
+			log.Debugf("auto discovered max_nodes = %v for node group %v", nodeGroupOpts.MaxNodes, nodeGroupOpts.Name)
+		}
+
 		nodegroupMap[nodeGroupOpts.Name] = &NodeGroupState{
 			Opts:                   nodeGroupOpts,
 			NodeGroupLister:        client.Listers[nodeGroupOpts.Name],


### PR DESCRIPTION
This adds support for auto-discovering min_nodes and max_nodes from the cloud provider
for each node group. The auto-discovering/setting of the values is only done on the
initial start of Escalator. It can be enabled/disabled by setting both min_nodes and
max_nodes to 0 or removing them from the node groups config.

/cc @wendorf 