### PR TITLE
simplify cloud provider node group access within controller

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -35,8 +35,6 @@ type NodeGroupState struct {
 
 	NodeInfoMap map[string]*cache.NodeInfo
 
-	CloudProviderNodeGroup cloudprovider.NodeGroup
-
 	scaleUpLock scaleLock
 
 	// used for tracking which nodes are tainted. testing when in dry mode
@@ -95,7 +93,6 @@ func NewController(opts Opts, stopChan <-chan struct{}) *Controller {
 		nodegroupMap[nodeGroupOpts.Name] = &NodeGroupState{
 			Opts:                   nodeGroupOpts,
 			NodeGroupLister:        client.Listers[nodeGroupOpts.Name],
-			CloudProviderNodeGroup: cloudProviderNodeGroup,
 			// Setup the scaleLock timeouts for this nodegroup
 			scaleUpLock: scaleLock{
 				minimumLockDuration: nodeGroupOpts.ScaleUpCoolDownPeriodDuration(),

--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/atlassian/escalator/pkg/cloudprovider"
 	"github.com/atlassian/escalator/pkg/k8s"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -244,7 +243,6 @@ func NewDefaultNodeGroupLister(allPodsLister v1lister.PodLister, allNodesLister 
 type nodeGroupsStateOpts struct {
 	nodeGroups             []NodeGroupOptions
 	client                 Client
-	cloudProviderNodeGroup map[string]cloudprovider.NodeGroup
 }
 
 // BuildNodeGroupsState builds a node group state
@@ -254,7 +252,6 @@ func BuildNodeGroupsState(opts nodeGroupsStateOpts) map[string]*NodeGroupState {
 		nodeGroupsState[ng.Name] = &NodeGroupState{
 			Opts:                   ng,
 			NodeGroupLister:        opts.client.Listers[ng.Name],
-			CloudProviderNodeGroup: opts.cloudProviderNodeGroup[ng.Name],
 			// Setup the scaleLock timeouts for this nodegroup
 			scaleUpLock: scaleLock{
 				minimumLockDuration: ng.ScaleUpCoolDownPeriodDuration(),

--- a/pkg/controller/scale_down.go
+++ b/pkg/controller/scale_down.go
@@ -75,8 +75,13 @@ func (c *Controller) TryRemoveTaintedNodes(opts scaleOpts) (int, error) {
 			podsRemaining += nodePodsRemaining
 		}
 
+		cloudProviderNodeGroup, ok := c.cloudProvider.GetNodeGroup(opts.nodeGroup.Opts.CloudProviderGroupName)
+		if !ok {
+			return 0, fmt.Errorf("cloud provider node group does not exist: %s", opts.nodeGroup.Opts.CloudProviderGroupName)
+		}
+
 		// Terminate the nodes in the cloud provider
-		err := opts.nodeGroup.CloudProviderNodeGroup.DeleteNodes(toBeDeleted...)
+		err := cloudProviderNodeGroup.DeleteNodes(toBeDeleted...)
 		if err != nil {
 			for _, nodeToDelete := range toBeDeleted {
 				log.WithError(err).Errorf("failed to terminate node in cloud provider %v, %v", nodeToDelete.Name, nodeToDelete.Spec.ProviderID)


### PR DESCRIPTION
This PR will simplify the method in which the node group's cloud provider node group is accessed within the controller. 

At the moment, it is accessed through a pointer in the node group's state. This pointer refers to the node group inside the private `nodeGroups` field inside the cloud provider. This could have the potential for undesirable behaviour and is a little confusing. To access a cloud provider node group, one should retrieve it from the cloud provider directly, using `GetNodeGroup(id)`.

Tests have been updated to ensure they access the cloud provider node group through the correct method.