### PR TITLE
Add scale lock summary metric to observe lock durations & count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ escalator
 
 nodegroups-*.yaml
 .idea/
+
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM golang:1.10 as builder
 WORKDIR /go/src/github.com/atlassian/escalator/
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-ADD ./ ./
+COPY Gopkg.toml Gopkg.lock Makefile ./
 RUN make setup
+COPY cmd cmd
+COPY pkg pkg
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo cmd/main.go
 
 FROM alpine:latest

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,19 @@
-.PHONY: build setup test test-race test-vet docker
+.PHONY: build setup test test-race test-vet docker clean distclean
 
-build:
-	go build -o escalator cmd/main.go
+TARGET=escalator
+# E.g. set this to -v (I.e. GOCMDOPTS=-v via shell) to get the go command to be verbose
+GOCMDOPTS?=
+SOURCES=$(shell for dir in pkg cmd; do if [ -d $$dir ]; then find $$dir -type f -iname '*.go'; fi; done)
 
-setup:
-	dep ensure -vendor-only
+$(TARGET): vendor $(SOURCES)
+	go build $(GOCMDOPTS) -o $(TARGET) cmd/main.go
+
+build: $(TARGET)
+
+setup: vendor
+
+vendor: Gopkg.lock Gopkg.toml
+	dep ensure -vendor-only $(GOCMDOPTS)
 
 test:
 	go test ./... -cover
@@ -15,5 +24,11 @@ test-race:
 test-vet:
 	go vet ./...
 
-docker:
+docker: Dockerfile
 	docker build -t atlassian/escalator .
+
+clean:
+	rm -f $(TARGET)
+
+distclean: clean
+	rm -rf vendor

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: $(TARGET)
 
 setup: vendor
 
-vendor: Gopkg.lock Gopkg.toml
+vendor: Gopkg.lock
 	dep ensure -vendor-only $(GOCMDOPTS)
 
 test:
@@ -32,3 +32,9 @@ clean:
 
 distclean: clean
 	rm -rf vendor
+
+Gopkg.lock: Gopkg.toml
+	dep ensure -update $(GOCMDOPTS)
+
+Gopkg.toml: $(SOURCES)
+	@if ! dep check; then touch $@; fi;

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -39,8 +39,10 @@ These are the metrics that Escalator exposes, and are subject to change:
 
  - **`escalator_node_group_taint_event`**: indicates a scale down event
  - **`escalator_node_group_untaint_event`**: indicates a scale up event
- - **`escalator_node_group_scale_lock`**: indicates if the nodegroup is locked from scaling
+ - **`escalator_node_group_scale_lock`**: indicates if the nodegroup is locked from scaling, zero is asserted unlocked, non-zero postivie locked
  - **`escalator_node_group_scale_delta`**: indicates current scale delta
+ - **`escalator_node_group_scale_lock_duration`**: summary metric of scale lock durations
+ - **`escalator_node_group_scale_lock_check_was_locked`**: counter of how many time the lock status was probed and found locked
  
 ### Cloud Provider
  

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ These are the metrics that Escalator exposes, and are subject to change:
  - **`escalator_node_group_untaint_event`**: indicates a scale up event
  - **`escalator_node_group_scale_lock`**: indicates if the nodegroup is locked from scaling, zero is asserted unlocked, non-zero postivie locked
  - **`escalator_node_group_scale_delta`**: indicates current scale delta
- - **`escalator_node_group_scale_lock_duration`**: summary metric of scale lock durations
+ - **`escalator_node_group_scale_lock_duration`**: histogram metric of scale lock durations, 60 second buckets from 1 … 30.
  - **`escalator_node_group_scale_lock_check_was_locked`**: counter of how many time the lock status was probed and found locked
  
 ### Cloud Provider

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -261,15 +261,12 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	metrics.NodeGroupsMemPercent.WithLabelValues(nodegroup).Set(memPercent)
 
 	locked := nodeGroup.scaleUpLock.locked()
-	lockVal := 0.0
 	if locked {
 		// don't do anything else until we're unlocked again
-		lockVal = 1.0
 		log.WithField("nodegroup", nodegroup).Info(nodeGroup.scaleUpLock)
 		log.WithField("nodegroup", nodegroup).Info("Waiting for scale to finish")
 		return nodeGroup.scaleUpLock.requestedNodes, nil
 	}
-	metrics.NodeGroupScaleLock.WithLabelValues(nodegroup).Observe(lockVal)
 
 	// Perform the scaling decision
 	maxPercent := math.Max(cpuPercent, memPercent)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -99,6 +99,7 @@ func NewController(opts Opts, stopChan <-chan struct{}) *Controller {
 			// Setup the scaleLock timeouts for this nodegroup
 			scaleUpLock: scaleLock{
 				minimumLockDuration: nodeGroupOpts.ScaleUpCoolDownPeriodDuration(),
+				nodegroup: nodeGroupOpts.Name,
 			},
 		}
 	}

--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -258,6 +258,7 @@ func BuildNodeGroupsState(opts nodeGroupsStateOpts) map[string]*NodeGroupState {
 			// Setup the scaleLock timeouts for this nodegroup
 			scaleUpLock: scaleLock{
 				minimumLockDuration: ng.ScaleUpCoolDownPeriodDuration(),
+				nodegroup: ng.Name,
 			},
 		}
 	}

--- a/pkg/controller/scale_lock.go
+++ b/pkg/controller/scale_lock.go
@@ -21,6 +21,7 @@ type scaleLock struct {
 // locked returns whether the scale lock is locked
 func (l *scaleLock) locked() bool {
 	if time.Now().Sub(l.lockTime) < l.minimumLockDuration {
+		metrics.NodeGroupScaleLockCheckWasLocked.WithLabelValues(l.nodegroup).Add(1.0)
 		return true
 	}
 	l.unlock()

--- a/pkg/controller/scale_lock.go
+++ b/pkg/controller/scale_lock.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/atlassian/escalator/pkg/metrics"
+
 	log "github.com/sirupsen/logrus"
 )
 
@@ -12,6 +14,8 @@ type scaleLock struct {
 	requestedNodes      int
 	lockTime            time.Time
 	minimumLockDuration time.Duration
+	// Needed for metrics label value
+	nodegroup           string
 }
 
 // locked returns whether the scale lock is locked
@@ -25,6 +29,9 @@ func (l *scaleLock) locked() bool {
 
 // lock locks the scale lock
 func (l *scaleLock) lock(nodes int) {
+	if l.isLocked {
+		log.Warn("Scale lock already locked")
+	}
 	log.Debug("Locking scale lock")
 	l.isLocked = true
 	l.requestedNodes = nodes
@@ -33,9 +40,14 @@ func (l *scaleLock) lock(nodes int) {
 
 // unlock unlocks the scale lock
 func (l *scaleLock) unlock() {
-	log.Debug("Unlocking scale lock")
-	l.isLocked = false
-	l.requestedNodes = 0
+	// Only if it's already locked, otherwise noop; handles frequent forced unlocking from the locked() call to avoid spurious metrics submission
+	if l.isLocked {
+		lockDuration := float64(time.Now().Sub(l.lockTime)) / 1000000000
+		log.Debug(fmt.Sprintf("Unlocking scale lock. Lock Duration: %0.0e Node Group: %s", lockDuration, l.nodegroup))
+		l.isLocked = false
+		l.requestedNodes = 0
+		metrics.NodeGroupScaleLockDuration.WithLabelValues(l.nodegroup).Observe(lockDuration)
+	}
 }
 
 // timeUntilMinimumUnlock returns the the time until the minimum unlock

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -160,6 +160,16 @@ var (
 		},
 		[]string{"node_group"},
 	)
+	// NodeGroupScaleLockCheckWasLocked indicates how many scale lock `locked()` checks were conduced whilst the lock was held
+	NodeGroupScaleLockCheckWasLocked = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "node_group_scale_lock_check_was_locked",
+			Namespace: NAMESPACE,
+			Help: "indicates how many checks of the nodegroup scale lock were done whilst the lock was held",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupScaleDelta indicates desired change in node group size
 	NodeGroupScaleDelta = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "node_group_scale_delta",
@@ -224,6 +234,7 @@ func init() {
 	prometheus.MustRegister(NodeGroupUntaintEvent)
 	prometheus.MustRegister(NodeGroupScaleLock)
 	prometheus.MustRegister(NodeGroupScaleLockDuration)
+	prometheus.MustRegister(NodeGroupScaleLockCheckWasLocked)
 	prometheus.MustRegister(NodeGroupScaleDelta)
 	prometheus.MustRegister(CloudProviderMinSize)
 	prometheus.MustRegister(CloudProviderMaxSize)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -142,8 +142,8 @@ var (
 		[]string{"node_group"},
 	)
 	// NodeGroupScaleLock indicates if the nodegroup is locked from scaling
-	NodeGroupScaleLock = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	NodeGroupScaleLock = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
 			Name: "node_group_scale_lock",
 			Namespace: NAMESPACE,
 			Help: "indicates if the nodegroup is locked from scaling",
@@ -151,11 +151,12 @@ var (
 		[]string{"node_group"},
 	)
 	// NodeGroupScaleLockDuration indicates how long the nodegroup is locked from scaling
-	NodeGroupScaleLockDuration = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	NodeGroupScaleLockDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "node_group_scale_lock_duration",
 			Namespace: NAMESPACE,
 			Help: "indicates how long the nodegroup is locked from scaling",
+			Buckets: []float64{1, 2, 3, 5, 8, 13, 21, 34, 55},
 		},
 		[]string{"node_group"},
 	)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -151,12 +151,11 @@ var (
 		[]string{"node_group"},
 	)
 	// NodeGroupScaleLockDuration indicates how long the nodegroup is locked from scaling
-	NodeGroupScaleLockDuration = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	NodeGroupScaleLockDuration = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
 			Name: "node_group_scale_lock_duration",
 			Namespace: NAMESPACE,
 			Help: "indicates how long the nodegroup is locked from scaling",
-			Buckets: []float64{1, 2, 3, 5, 8, 13, 21, 34, 55},
 		},
 		[]string{"node_group"},
 	)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -151,11 +151,12 @@ var (
 		[]string{"node_group"},
 	)
 	// NodeGroupScaleLockDuration indicates how long the nodegroup is locked from scaling
-	NodeGroupScaleLockDuration = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
+	NodeGroupScaleLockDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "node_group_scale_lock_duration",
 			Namespace: NAMESPACE,
 			Help: "indicates how long the nodegroup is locked from scaling",
+			Buckets: []float64{60, 120, 180, 240, 300, 360, 420, 480, 540, 600, 660, 720, 780, 840, 900, 960, 1020, 1080, 1140, 1200, 1260, 1320, 1380, 1440, 1500, 1560, 1620, 1680, 1740},
 		},
 		[]string{"node_group"},
 	)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -150,6 +150,15 @@ var (
 		},
 		[]string{"node_group"},
 	)
+	// NodeGroupScaleLockDuration indicates how long the nodegroup is locked from scaling
+	NodeGroupScaleLockDuration = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name: "node_group_scale_lock_duration",
+			Namespace: NAMESPACE,
+			Help: "indicates how long the nodegroup is locked from scaling",
+		},
+		[]string{"node_group"},
+	)
 	NodeGroupScaleDelta = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "node_group_scale_delta",
@@ -213,6 +222,7 @@ func init() {
 	prometheus.MustRegister(NodeGroupTaintEvent)
 	prometheus.MustRegister(NodeGroupUntaintEvent)
 	prometheus.MustRegister(NodeGroupScaleLock)
+	prometheus.MustRegister(NodeGroupScaleLockDuration)
 	prometheus.MustRegister(NodeGroupScaleDelta)
 	prometheus.MustRegister(CloudProviderMinSize)
 	prometheus.MustRegister(CloudProviderMaxSize)


### PR DESCRIPTION
- Related to #60 
- Added `node_group_scale_lock_duration` histogram to expose lock durations
- Fixed utility of `node_group_scale_lock`; as is now a gauge and is calculated directly from the lock.
- Added `node_group_scale_lock_check_was_locked` counter to expose how many times the lock was checked and found held.
- Some `Makefile` and `Dockerfile` improvements around dependency management and change detection