### PR TITLE
Ensure min_nodes and max_nodes are up to date with the cloud provider.

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -395,15 +395,15 @@ func (c *Controller) RunOnce() error {
 		// Double check if node group still exists from the cloud provider then retrieve the latest stat
 		cloudProviderNodeGroup, ok := c.cloudProvider.GetNodeGroup(nodeGroupOpts.CloudProviderGroupName)
 		if !ok {
-  		err = errors.New("could not find node group!")
-  		return err
+			err = errors.New("could not find node group!")
+			return err
 		}
 		// Update the min_nodes and max_nodes based on the latest value from the cloud provider
 		if nodeGroupOpts.autoDiscoverMinMaxNodeOptions() {
-  		state.Opts.MinNodes = int(cloudProviderNodeGroup.MinSize())
-  		log.Debugf("auto discovered min_nodes = %v for node group %v", state.Opts.MinNodes, nodeGroupOpts.Name)
-  		state.Opts.MaxNodes = int(cloudProviderNodeGroup.MaxSize())
-  		log.Debugf("auto discovered max_nodes = %v for node group %v", state.Opts.MaxNodes, nodeGroupOpts.Name)
+			state.Opts.MinNodes = int(cloudProviderNodeGroup.MinSize())
+			log.Debugf("auto discovered min_nodes = %v for node group %v", state.Opts.MinNodes, nodeGroupOpts.Name)
+			state.Opts.MaxNodes = int(cloudProviderNodeGroup.MaxSize())
+			log.Debugf("auto discovered max_nodes = %v for node group %v", state.Opts.MaxNodes, nodeGroupOpts.Name)
 		}
 		delta, err := c.scaleNodeGroup(nodeGroupOpts.Name, state)
 		metrics.NodeGroupScaleDelta.WithLabelValues(nodeGroupOpts.Name).Set(float64(delta))


### PR DESCRIPTION
During our testing, there's possibility that the min_nodes / max_nodes value can be updated via the AWS console or through API. This will help to ensure the RunOnce loop keep the min_nodes and max_nodes up to date.