### PR TITLE
Add support for one-shot capacity using AWS Fleet

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -64,14 +64,21 @@ func (b cloudProviderBuilder) Build() (cloudprovider.CloudProvider, error) {
 
 // setupCloudProvider creates the cloudprovider builder with the nodegroup opts
 func setupCloudProvider(nodegroups []controller.NodeGroupOptions) cloudprovider.Builder {
-	var nodegroupIDs []string
+	var nodeGroupConfigs []cloudprovider.NodeGroupConfig
 	for _, n := range nodegroups {
-		nodegroupIDs = append(nodegroupIDs, n.CloudProviderGroupName)
+		nodeGroupConfigs = append(nodeGroupConfigs, cloudprovider.NodeGroupConfig{
+			GroupID: n.CloudProviderGroupName,
+			AWSConfig: cloudprovider.AWSNodeGroupConfig{
+				LaunchTemplateID:          n.AWS.LaunchTemplateID,
+				LaunchTemplateVersion:     n.AWS.LaunchTemplateVersion,
+				FleetInstanceReadyTimeout: n.AWS.FleetInstanceReadyTimeoutDuration(),
+			},
+		})
 	}
 	cloudBuilder := cloudProviderBuilder{
 		ProviderOpts: cloudprovider.BuildOpts{
-			ProviderID:   *cloudProviderID,
-			NodeGroupIDs: nodegroupIDs,
+			ProviderID:       *cloudProviderID,
+			NodeGroupConfigs: nodeGroupConfigs,
 		},
 	}
 	return cloudBuilder

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"testing"
 
+	"github.com/atlassian/escalator/pkg/cloudprovider"
 	"github.com/atlassian/escalator/pkg/test"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -31,8 +32,13 @@ func newMockCloudProvider(nodeGroups []string, service *test.MockAutoscalingServ
 		nodeGroups:  make(map[string]*NodeGroup, len(nodeGroups)),
 	}
 
+	configs := make([]cloudprovider.NodeGroupConfig, 0, len(nodeGroups))
+	for _, i := range nodeGroups {
+		configs = append(configs, cloudprovider.NodeGroupConfig{GroupID: i})
+	}
+
 	if service != nil {
-		err = cloudProvider.RegisterNodeGroups(nodeGroups...)
+		err = cloudProvider.RegisterNodeGroups(configs...)
 	}
 
 	return cloudProvider, err

--- a/pkg/cloudprovider/aws/builder.go
+++ b/pkg/cloudprovider/aws/builder.go
@@ -44,11 +44,11 @@ func (b Builder) Build() (cloudprovider.CloudProvider, error) {
 	cloud := &CloudProvider{
 		service:     service,
 		ec2_service: ec2_service,
-		nodeGroups:  make(map[string]*NodeGroup, len(b.ProviderOpts.NodeGroupIDs)),
+		nodeGroups:  make(map[string]*NodeGroup, len(b.ProviderOpts.NodeGroupConfigs)),
 	}
 
 	// Register the node groups
-	err = cloud.RegisterNodeGroups(b.ProviderOpts.NodeGroupIDs...)
+	err = cloud.RegisterNodeGroups(b.ProviderOpts.NodeGroupConfigs...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudprovider/aws/cloud_provider_test.go
+++ b/pkg/cloudprovider/aws/cloud_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/atlassian/escalator/pkg/cloudprovider"
 	"github.com/atlassian/escalator/pkg/test"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -25,15 +26,14 @@ func TestCloudProvider_NodeGroups(t *testing.T) {
 		{
 			"single node group",
 			map[string]*NodeGroup{
-				"1": NewNodeGroup("1", &autoscaling.Group{}, &CloudProvider{}),
+				"1": NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: "1"}, &autoscaling.Group{}, &CloudProvider{}),
 			},
 		},
 		{
 			"multiple node groups",
 			map[string]*NodeGroup{
-				"1": NewNodeGroup("1", &autoscaling.Group{}, &CloudProvider{}),
-				"2": NewNodeGroup("2", &autoscaling.Group{}, &CloudProvider{}),
-			},
+				"1": NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: "1"}, &autoscaling.Group{}, &CloudProvider{}),
+				"2": NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: "2"}, &autoscaling.Group{}, &CloudProvider{})},
 		},
 		{
 			"no node groups",
@@ -61,7 +61,7 @@ func TestCloudProvider_GetNodeGroup(t *testing.T) {
 		{
 			"get a node group that exists",
 			map[string]*NodeGroup{
-				"1": NewNodeGroup("1", &autoscaling.Group{}, &CloudProvider{}),
+				"1": NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: "1"}, &autoscaling.Group{}, &CloudProvider{}),
 			},
 			"1",
 			true,

--- a/pkg/cloudprovider/aws/node_group_test.go
+++ b/pkg/cloudprovider/aws/node_group_test.go
@@ -17,12 +17,12 @@ import (
 
 func TestNodeGroup_ID(t *testing.T) {
 	id := "nodegroup"
-	nodeGroup := NewNodeGroup(id, &autoscaling.Group{}, &CloudProvider{})
+	nodeGroup := NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: id}, &autoscaling.Group{}, &CloudProvider{})
 	assert.Equal(t, id, nodeGroup.ID())
 }
 
 func TestNodeGroup_String(t *testing.T) {
-	nodeGroup := NewNodeGroup("nodegroup", &autoscaling.Group{}, &CloudProvider{})
+	nodeGroup := NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: "nodegroup"}, &autoscaling.Group{}, &CloudProvider{})
 	assert.IsType(t, "string", nodeGroup.String())
 }
 
@@ -33,7 +33,7 @@ func TestNodeGroup_MinSize(t *testing.T) {
 		MinSize: aws.Int64(minSize),
 	}
 
-	nodeGroup := NewNodeGroup("nodegroup", asg, &CloudProvider{})
+	nodeGroup := NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: "nodegroup"}, asg, &CloudProvider{})
 	assert.Equal(t, minSize, nodeGroup.MinSize())
 }
 
@@ -44,7 +44,7 @@ func TestNodeGroup_MaxSize(t *testing.T) {
 		MaxSize: aws.Int64(maxSize),
 	}
 
-	nodeGroup := NewNodeGroup("nodegroup", asg, &CloudProvider{})
+	nodeGroup := NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: "nodegroup"}, asg, &CloudProvider{})
 	assert.Equal(t, maxSize, nodeGroup.MaxSize())
 }
 
@@ -56,7 +56,7 @@ func TestNodeGroup_TargetSize(t *testing.T) {
 		DesiredCapacity: aws.Int64(desiredCapacity),
 	}
 
-	nodeGroup := NewNodeGroup(id, asg, &CloudProvider{})
+	nodeGroup := NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: id}, asg, &CloudProvider{})
 	assert.Equal(t, desiredCapacity, nodeGroup.TargetSize())
 }
 
@@ -92,7 +92,7 @@ func TestNodeGroup_Size(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			asg := &autoscaling.Group{Instances: tt.instances}
-			nodeGroup := NewNodeGroup("nodegroup", asg, &CloudProvider{})
+			nodeGroup := NewNodeGroup(&cloudprovider.NodeGroupConfig{GroupID: "nodegroup"}, asg, &CloudProvider{})
 			assert.Equal(t, tt.expected, nodeGroup.Size())
 		})
 	}

--- a/pkg/cloudprovider/interface.go
+++ b/pkg/cloudprovider/interface.go
@@ -20,7 +20,7 @@ type CloudProvider interface {
 	GetNodeGroup(string) (NodeGroup, bool)
 
 	// RegisterNodeGroup adds the nodegroup to the list of nodes groups
-	RegisterNodeGroups(...string) error
+	RegisterNodeGroups(...NodeGroupConfig) error
 
 	// Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 	// In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
@@ -93,6 +93,20 @@ type Builder interface {
 
 // BuildOpts providers all options to create your cloud provider
 type BuildOpts struct {
-	ProviderID   string
-	NodeGroupIDs []string
+	ProviderID       string
+	NodeGroupConfigs []NodeGroupConfig
+}
+
+// NodeGroupConfig contains the configuration for a node group
+type NodeGroupConfig struct {
+	GroupID   string
+	AWSConfig AWSNodeGroupConfig
+}
+
+// AWSNodeGroupConfig contains the AWS cloud provider specific configuration
+// for a node group
+type AWSNodeGroupConfig struct {
+	LaunchTemplateID          string
+	LaunchTemplateVersion     string
+	FleetInstanceReadyTimeout time.Duration
 }

--- a/pkg/test/cloud_provider.go
+++ b/pkg/test/cloud_provider.go
@@ -37,7 +37,7 @@ func (c *CloudProvider) GetNodeGroup(id string) (cloudprovider.NodeGroup, bool) 
 	return ng, ok
 }
 
-func (c *CloudProvider) RegisterNodeGroups(ids ...string) error {
+func (c *CloudProvider) RegisterNodeGroups(groups ...cloudprovider.NodeGroupConfig) error {
 	return nil
 }
 


### PR DESCRIPTION
This PR adds support for acquiring all desired scale-up capacity at one time using the [EC2 Fleet API](https://aws.amazon.com/blogs/aws/ec2-fleet-manage-thousands-of-on-demand-and-spot-instances-with-one-request/).

To use this create an instance launch template and add the ID to your Escalator configuration. The presence of this setting will cause Escalator to use the fleet API to acquire the capacity in one-shot and add it into the autoscaling group rather than changing the desired instance count of the autoscaling group and waiting for instances to be delivered. If there are not sufficient instances available to satisfy the scaling request the request will fail and try again next time Escalator checks for scaling-up the cluster.