### PR TITLE
#168: Untaint first when less than min nodes

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -281,9 +281,11 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	if len(untaintedNodes) < nodeGroup.Opts.MinNodes {
 		log.WithField("nodegroup", nodegroup).Warn("There are less untainted nodes than the minimum")
 		result, err := c.ScaleUp(scaleOpts{
-			nodes:      allNodes,
-			nodesDelta: nodeGroup.Opts.MinNodes - len(untaintedNodes),
-			nodeGroup:  nodeGroup,
+			nodes:          allNodes,
+			nodesDelta:     nodeGroup.Opts.MinNodes - len(untaintedNodes),
+			nodeGroup:      nodeGroup,
+			taintedNodes:   taintedNodes,
+			untaintedNodes: untaintedNodes,
 		})
 		if err != nil {
 			log.WithField("nodegroup", nodegroup).Error(err)


### PR DESCRIPTION
Closes #168 

Pass through tainted and untainted nodes to to scale up. Fixes the edge cases where min nodes gets adjusted live in the cloud provider and a scale up is needed with tainted nodes available. 

Also adds test for edge case