### PR TITLE
#160: Check for NodeAffinityOperator

### DIFF
--- a/pkg/controller/node_group_test.go
+++ b/pkg/controller/node_group_test.go
@@ -11,13 +11,13 @@ import (
 )
 
 func TestNewPodLabelFilterFunc(t *testing.T) {
-	buildengPod := test.BuildTestPod(test.PodOpts{
+	examplePod := test.BuildTestPod(test.PodOpts{
 		NodeSelectorKey:   "customer",
-		NodeSelectorValue: "buildeng",
+		NodeSelectorValue: "example",
 	})
 	badKeyPod := test.BuildTestPod(test.PodOpts{
 		NodeSelectorKey:   "wronglabelkey",
-		NodeSelectorValue: "buildeng",
+		NodeSelectorValue: "example",
 	})
 	badLabelPod := test.BuildTestPod(test.PodOpts{
 		NodeSelectorKey:   "customer",
@@ -29,12 +29,17 @@ func TestNewPodLabelFilterFunc(t *testing.T) {
 	})
 	daemonSet := test.BuildTestPod(test.PodOpts{
 		NodeSelectorKey:   "customer",
-		NodeSelectorValue: "buildeng",
+		NodeSelectorValue: "example",
 		Owner:             "DaemonSet",
 	})
 	affinity := test.BuildTestPod(test.PodOpts{
 		NodeAffinityKey:   "customer",
-		NodeAffinityValue: "buildeng",
+		NodeAffinityValue: "example",
+	})
+	affinityIncorrectOp := test.BuildTestPod(test.PodOpts{
+		NodeAffinityKey:   "customer",
+		NodeAffinityValue: "example",
+		NodeAffinityOp:    v1.NodeSelectorOpNotIn,
 	})
 
 	type args struct {
@@ -48,46 +53,46 @@ func TestNewPodLabelFilterFunc(t *testing.T) {
 		want bool
 	}{
 		{
-			"buildeng customer should pass",
+			"example customer should pass",
 			args{
 				"customer",
-				"buildeng",
-				buildengPod,
+				"example",
+				examplePod,
 			},
 			true,
 		},
 		{
-			"buildeng customer should fail",
+			"example customer should fail",
 			args{
 				"customer",
 				"kitt",
-				buildengPod,
+				examplePod,
 			},
 			false,
 		},
 		{
-			"buildeng wrong key should fail",
+			"example wrong key should fail",
 			args{
 				"customer",
-				"buildeng",
+				"example",
 				badKeyPod,
 			},
 			false,
 		},
 		{
-			"buildeng wrong value should fail",
+			"example wrong value should fail",
 			args{
 				"customer",
-				"buildeng",
+				"example",
 				badLabelPod,
 			},
 			false,
 		},
 		{
-			"buildeng bad both should fail",
+			"example bad both should fail",
 			args{
 				"customer",
-				"buildeng",
+				"example",
 				badBothPod,
 			},
 			false,
@@ -96,26 +101,35 @@ func TestNewPodLabelFilterFunc(t *testing.T) {
 			"daemonset should be false",
 			args{
 				"customer",
-				"buildeng",
+				"example",
 				daemonSet,
 			},
 			false,
 		},
 		{
-			"correct affinty should be true",
+			"correct affinity should be true",
 			args{
 				"customer",
-				"buildeng",
+				"example",
 				affinity,
 			},
 			true,
 		},
 		{
-			"wrong affinty should be false",
+			"wrong affinity should be false",
 			args{
 				"customer",
 				"shared",
 				affinity,
+			},
+			false,
+		},
+		{
+			"correct affinity wrong operator should be false",
+			args{
+				"customer",
+				"shared",
+				affinityIncorrectOp,
 			},
 			false,
 		},
@@ -130,9 +144,9 @@ func TestNewPodLabelFilterFunc(t *testing.T) {
 }
 
 func TestNewPodDefaultFilterFunc(t *testing.T) {
-	buildengPod := test.BuildTestPod(test.PodOpts{
+	examplePod := test.BuildTestPod(test.PodOpts{
 		NodeSelectorKey:   "customer",
-		NodeSelectorValue: "buildeng",
+		NodeSelectorValue: "example",
 	})
 	sharedPod := test.BuildTestPod(test.PodOpts{
 		NodeSelectorKey:   "customer",
@@ -162,9 +176,9 @@ func TestNewPodDefaultFilterFunc(t *testing.T) {
 		want bool
 	}{
 		{
-			"buildeng customer should fail",
+			"example customer should fail",
 			args{
-				buildengPod,
+				examplePod,
 			},
 			false,
 		},
@@ -221,13 +235,13 @@ func TestNewPodDefaultFilterFunc(t *testing.T) {
 }
 
 func TestNewNodeLabelFilterFunc(t *testing.T) {
-	buildengNode := test.BuildTestNode(test.NodeOpts{
+	exampleNode := test.BuildTestNode(test.NodeOpts{
 		LabelKey:   "customer",
-		LabelValue: "buildeng",
+		LabelValue: "example",
 	})
 	badKeyNode := test.BuildTestNode(test.NodeOpts{
 		LabelKey:   "wronglabelkey",
-		LabelValue: "buildeng",
+		LabelValue: "example",
 	})
 	badLabelNode := test.BuildTestNode(test.NodeOpts{
 		LabelKey:   "customer",
@@ -249,46 +263,46 @@ func TestNewNodeLabelFilterFunc(t *testing.T) {
 		want bool
 	}{
 		{
-			"buildeng customer should pass",
+			"example customer should pass",
 			args{
 				"customer",
-				"buildeng",
-				buildengNode,
+				"example",
+				exampleNode,
 			},
 			true,
 		},
 		{
-			"buildeng customer should fail",
+			"example customer should fail",
 			args{
 				"customer",
 				"kitt",
-				buildengNode,
+				exampleNode,
 			},
 			false,
 		},
 		{
-			"buildeng wrong key should fail",
+			"example wrong key should fail",
 			args{
 				"customer",
-				"buildeng",
+				"example",
 				badKeyNode,
 			},
 			false,
 		},
 		{
-			"buildeng wrong value should fail",
+			"example wrong value should fail",
 			args{
 				"customer",
-				"buildeng",
+				"example",
 				badLabelNode,
 			},
 			false,
 		},
 		{
-			"buildeng bad both should fail",
+			"example bad both should fail",
 			args{
 				"customer",
-				"buildeng",
+				"example",
 				badBothNode,
 			},
 			false,
@@ -311,9 +325,9 @@ func TestUnmarshalNodeGroupOptions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 2, len(opts))
 		assert.NotNil(t, opts[0])
-		assert.Equal(t, "buildeng", opts[0].Name)
+		assert.Equal(t, "example", opts[0].Name)
 		assert.Equal(t, "customer", opts[0].LabelKey)
-		assert.Equal(t, "buildeng", opts[0].LabelValue)
+		assert.Equal(t, "example", opts[0].LabelValue)
 		assert.Equal(t, 5, opts[0].MinNodes)
 		assert.Equal(t, 300, opts[0].MaxNodes)
 		assert.Equal(t, true, opts[0].DryMode)
@@ -340,16 +354,16 @@ func TestUnmarshalNodeGroupOptions(t *testing.T) {
 		assert.Empty(t, opts)
 	})
 
-	t.Run("test yaml unmarshal Buildeng good", func(t *testing.T) {
+	t.Run("test yaml unmarshal example good", func(t *testing.T) {
 		yamlReader := strings.NewReader(yamlBE)
 		opts, err := UnmarshalNodeGroupOptions(yamlReader)
 
 		assert.NoError(t, err)
 		assert.Equal(t, 1, len(opts))
 		assert.NotNil(t, opts[0])
-		assert.Equal(t, "buildeng", opts[0].Name)
+		assert.Equal(t, "example", opts[0].Name)
 		assert.Equal(t, "customer", opts[0].LabelKey)
-		assert.Equal(t, "buildeng", opts[0].LabelValue)
+		assert.Equal(t, "example", opts[0].LabelValue)
 		assert.Equal(t, 10, opts[0].MinNodes)
 		assert.Equal(t, 300, opts[0].MaxNodes)
 		assert.Equal(t, false, opts[0].DryMode)
@@ -364,9 +378,9 @@ node_groups:
 
 var yamlValid = `
 node_groups:
-  - name: "buildeng"
+  - name: "example"
     label_key: "customer"
-    label_value: "buildeng"
+    label_value: "example"
     min_nodes: 5
     max_nodes: 300
     dry_mode: true
@@ -395,9 +409,9 @@ node_groups:
 `
 
 var yamlBE = `node_groups:
-  - name: "buildeng"
+  - name: "example"
     label_key: "customer"
-    label_value: "buildeng"
+    label_value: "example"
     min_nodes: 10
     max_nodes: 300
     dry_mode: false

--- a/pkg/controller/scale_down_test.go
+++ b/pkg/controller/scale_down_test.go
@@ -42,7 +42,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 
 	nodeGroups := []NodeGroupOptions{
 		{
-			Name:     "buildeng",
+			Name:     "example",
 			MinNodes: 3,
 			MaxNodes: 6,
 			DryMode:  false,
@@ -87,7 +87,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 					nodes,
 					[]*v1.Node{},
 					nodes,
-					nodeGroupsState["buildeng"],
+					nodeGroupsState["example"],
 					2,
 				},
 			},
@@ -102,7 +102,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 					nodes,
 					[]*v1.Node{},
 					nodes,
-					nodeGroupsState["buildeng"],
+					nodeGroupsState["example"],
 					4,
 				},
 			},
@@ -117,7 +117,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 					nodes[:2],
 					[]*v1.Node{},
 					nodes[:2],
-					nodeGroupsState["buildeng"],
+					nodeGroupsState["example"],
 					4,
 				},
 			},
@@ -180,7 +180,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 					<-updateChan
 				}
 			}
-			nodeGroupsState["buildeng"].taintTracker = nil
+			nodeGroupsState["example"].taintTracker = nil
 		})
 	}
 }
@@ -216,7 +216,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 
 	nodeGroups := []NodeGroupOptions{
 		{
-			Name:     "buildeng",
+			Name:     "example",
 			MinNodes: 1,
 			MaxNodes: 5,
 			DryMode:  false,
@@ -251,7 +251,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 			"first 3 nodes. taint 3",
 			args{
 				nodes[:3],
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				3,
 			},
 			[]int{1, 2, 0},
@@ -260,7 +260,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 			"first 3 nodes. taint 2",
 			args{
 				nodes[:3],
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				2,
 			},
 			[]int{1, 2},
@@ -269,7 +269,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 			"6 nodes. taint 0",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				0,
 			},
 			[]int{},
@@ -278,7 +278,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 			"6 nodes. taint 2",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				2,
 			},
 			[]int{4, 5},
@@ -287,7 +287,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 			"6 nodes. taint 6",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				6,
 			},
 			[]int{4, 5, 1, 2, 0, 3},
@@ -296,7 +296,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 			"6 nodes. taint 5",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				5,
 			},
 			[]int{4, 5, 1, 2, 0},
@@ -305,7 +305,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 			"6 nodes. taint 7",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				7,
 			},
 			[]int{4, 5, 1, 2, 0, 3},
@@ -314,7 +314,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 			"4 nodes. taint 1",
 			args{
 				nodes[:4],
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				1,
 			},
 			[]int{1},
@@ -357,7 +357,7 @@ func TestControllerTaintOldestN(t *testing.T) {
 					<-updateChan
 				}
 			}
-			nodeGroupsState["buildeng"].taintTracker = nil
+			nodeGroupsState["example"].taintTracker = nil
 		})
 	}
 }

--- a/pkg/controller/scale_up_test.go
+++ b/pkg/controller/scale_up_test.go
@@ -45,7 +45,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 
 	nodeGroups := []NodeGroupOptions{
 		{
-			Name:     "buildeng",
+			Name:     "example",
 			MinNodes: 1,
 			MaxNodes: 5,
 			DryMode:  false,
@@ -81,7 +81,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			"first 3 nodes. untaint 3",
 			args{
 				nodes[:3],
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				3,
 			},
 			[]int{0, 2, 1},
@@ -90,7 +90,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			"first 3 nodes. untaint 2",
 			args{
 				nodes[:3],
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				2,
 			},
 			[]int{0, 2},
@@ -99,7 +99,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			"6 nodes. untaint 0",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				0,
 			},
 			[]int{},
@@ -108,7 +108,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			"6 nodes. untaint 2",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				2,
 			},
 			[]int{3, 0},
@@ -117,7 +117,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			"6 nodes. untaint 6",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				6,
 			},
 			[]int{3, 0, 2, 1, 5, 4},
@@ -126,7 +126,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			"6 nodes. untaint 5",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				5,
 			},
 			[]int{3, 0, 2, 1, 5},
@@ -135,7 +135,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			"6 nodes. untaint 7",
 			args{
 				nodes,
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				7,
 			},
 			[]int{3, 0, 2, 1, 5, 4},
@@ -144,7 +144,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			"4 nodes. untaint 1",
 			args{
 				nodes[:4],
-				nodeGroupsState["buildeng"],
+				nodeGroupsState["example"],
 				1,
 			},
 			[]int{3},
@@ -164,7 +164,7 @@ func TestControllerUntaintNewestN(t *testing.T) {
 			for _, node := range nodes {
 				if _, tainted := k8s.GetToBeRemovedTaint(node); !tainted {
 					k8s.AddToBeRemovedTaint(node, client, "NoSchedule")
-					nodeGroupsState["buildeng"].taintTracker = append(nodeGroupsState["buildeng"].taintTracker, node.Name)
+					nodeGroupsState["example"].taintTracker = append(nodeGroupsState["example"].taintTracker, node.Name)
 					<-updateChan
 					tc++
 				}


### PR DESCRIPTION
Closes #160 

Fixes bug where Escalator would not check for the NodeAffinityOperator and would match "NotIn", etc. 

Escalator will now only the "In" operator, as it is the only one that semantically makes sense with Escalator's use case right now

Also cleanup test nodegroup names and some typos