### PR TITLE
regist http metrics on a new mux

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -257,6 +257,7 @@ func init() {
 
 // Start starts the metrics endpoint on a new thread
 func Start(addr string) {
-	http.Handle("/metrics", promhttp.Handler())
-	go http.ListenAndServe(addr, nil)
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.Handler())
+	go http.ListenAndServe(addr, mux)
 }


### PR DESCRIPTION
We don't want to register metrics handler on the global mux, so creating a new one only for metrics.