### PR TITLE
Adds Node Ignore from Deletion annotation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,11 @@
     - Scale up
     - Scale down
     - Scale lock
+    - Tainting of nodes
+    - Cordoning of nodes
 - [**Node Termination**](./node-termination.md)
     - Node selection method for termination
+    - Annotating nodes / Stopping termination of selected nodes
 - [**Pod and Node Selectors**](./pod-node-selectors.md)
     - Nodes
     - Pods

--- a/docs/node-termination.md
+++ b/docs/node-termination.md
@@ -19,7 +19,7 @@ using the latest configuration.
 
 ### Annotating nodes / Stopping termination of selected nodes
 
-For most cases when wanting to exclude a node from termination for maintenance,you should first consider the [**cordon function**](./scale-process).
+For most cases when wanting to exclude a node from termination for maintenance, you should first consider the [**cordon function**](./scale-process).
 Cordoning a node filters it out from calculation **and** scaling processes (tainting and deletion). Additionally, cordoning a node in Kubernetes marks it Unschedule-able, so it won't accept workloads while in this state.
  
 In the cases where Cordoning is not acceptable, because you want your node to continue to receive workloads but not be deleted, you can annotate the node to tell escalator to treat it as normal, except for stopping it from being deleted.

--- a/docs/node-termination.md
+++ b/docs/node-termination.md
@@ -19,7 +19,7 @@ using the latest configuration.
 
 ### Annotating nodes / Stopping termination of selected nodes
 
-For most cases when wanting to exclude a node from termination for maintenance, you should first consider if the Cordon function [**Cordoning of nodes**](./scale-process).
+For most cases when wanting to exclude a node from termination for maintenance,you should first consider the [**cordon function**](./scale-process).
 Cordoning a node filters it out from calculation **and** scaling processes (tainting and deletion). Additionally, cordoning a node in Kubernetes marks it Unschedule-able, so it won't accept workloads while in this state.
  
 In the cases where Cordoning is not acceptable, because you want your node to continue to receive workloads but not be deleted, you can annotate the node to tell escalator to treat it as normal, except for stopping it from being deleted.

--- a/docs/node-termination.md
+++ b/docs/node-termination.md
@@ -16,3 +16,39 @@ where we compare the creation timestamps of each node.
 This method is useful to ensure there are always new nodes in the cluster. If you want to deploy a configuration change
 to your nodes, you can use Escalator to cycle the nodes by terminating the oldest first until all of the nodes are
 using the latest configuration.
+
+### Annotating nodes / Stopping termination of selected nodes
+
+For most cases when wanting to exclude a node from termination for maintenance, you should first consider if the Cordon function [**Cordoning of nodes**](./scale-process).
+Cordoning a node filters it out from calculation **and** scaling processes (tainting and deletion). Additionally, cordoning a node in Kubernetes marks it Unschedule-able, so it won't accept workloads while in this state.
+ 
+In the cases where Cordoning is not acceptable, because you want your node to continue to receive workloads but not be deleted, you can annotate the node to tell escalator to treat it as normal, except for stopping it from being deleted.
+This means the node will still factor into scaling calculations, and get tainted, untainted as the cluster scales, but if it is in a situation where it would be deleted normally, escalator will skip it and leave it active.
+
+#### To annotate a node:
+
+**Annotation key:** `atlassian.com/no-delete`
+
+The annotation value can be any **non empty** string that conforms to the Kubernetes annotation value standards. This can usually indicate the reason for annotation which will appear in logs
+
+**Example:**
+
+`kubectl edit node <node-name>`
+
+**Simple example:**
+```yaml
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    atlassian.com/no-delete: "true"
+```
+
+**An elaborate reason:**
+```yaml
+apiVersion: v1
+kind: Node
+metadata:
+  annotations:
+    atlassian.com/no-delete: "testing some long running bpf tracing"
+```

--- a/docs/scale-process.md
+++ b/docs/scale-process.md
@@ -77,5 +77,5 @@ Escalator taints are given the `atlassian.com/escalator` key.
 Escalator does not use the cordoning command anywhere in it's process. This is done to preserve the cordoning command
 for system administrators to filter the cordoned node out of calculations. This way, a faulty or misbehaving node
 can be cordoned by the system administrator to be debugged or troubleshooted without worrying about the node being 
-tainted and then terminated by Escalator. 
+tainted and then terminated by Escalator.
 


### PR DESCRIPTION
Closes #184 

Adds the ability to mark a node safe from deletion with an annotation.
Annotation key `com.atlassian/escalator-ignore`
Value can be any non empty string. Can be used for reason of ignore.

Adds unit tests for `TryRemoveTaintedNodes` function