### PR TITLE
Add AWS EC2 Spot functionality to Escalator

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -75,6 +75,8 @@ func setupCloudProvider(nodegroups []controller.NodeGroupOptions) cloudprovider.
 				LaunchTemplateID:          n.AWS.LaunchTemplateID,
 				LaunchTemplateVersion:     n.AWS.LaunchTemplateVersion,
 				FleetInstanceReadyTimeout: n.AWS.FleetInstanceReadyTimeoutDuration(),
+				Lifecycle:                 n.AWS.Lifecycle,
+				InstanceTypeOverrides:     n.AWS.InstanceTypeOverrides,
 			},
 		})
 	}

--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -30,6 +30,8 @@ node_groups:
         fleet_instance_ready_timeout: 1m
         launch_template_version: lt-1a2b3c4d
         launch_template_id: "1"
+        lifecycle: on-demand
+        instance_type_overrides: ["t2.large", "t3.large"]
 ```
 
 ## Options
@@ -224,3 +226,19 @@ numeric string. This value can be obtained through the AWS EC2 console on the La
 `LatestVersionNumber` or `DefaultVersionNumber` field returned from the
 [create-launch-template](https://docs.aws.amazon.com/cli/latest/reference/ec2/create-launch-template.html) CLI command
 and AWS API call.
+
+### `aws.lifecyle`
+
+Dependent on Launch Template ID being specified.
+
+This optional value is the lifecycle of the instances that will be launched. The accepted values are strings of either
+`on-demand` or `spot` to request On-Demand or Spot instances respectively. If no value is specified this will default
+to `on-demand`.
+
+### `aws.instance_type_overrides`
+
+Dependent on Launch Template ID being specified.
+
+An optional list of instance types to override the instance type within the launch template. Providing multiple instance
+types here increases the likelihood of a Spot request being successful. If omitted the instance type to request will
+be taken from the launch template.

--- a/docs/deployment/aws/README.md
+++ b/docs/deployment/aws/README.md
@@ -19,9 +19,13 @@ Escalator requires the following IAM policy to be able to properly integrate wit
       "Effect": "Allow",
       "Action": [
         "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DescribeTags",
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
-        "ec2:DescribeInstances"
+        "ec2:DescribeInstances",
+        "ec2:DescribeLaunchTemplateVersions"
       ],
       "Resource": "*"
     }
@@ -99,3 +103,5 @@ region.
 - Do not use 
  [Auto Scaling Lifecycle Hooks](https://docs.aws.amazon.com/autoscaling/ec2/userguide/lifecycle-hooks.html) for
  terminating of instances as Escalator will handle the termination of instances itself. 
+- If using launch templates do not use the "network settings" area to configure the security groups. The security groups
+ should be configured via a network interface.

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -19,9 +19,11 @@ import (
 
 const (
 	// ProviderName identifies this module as aws
-	ProviderName      = "aws"
+	ProviderName = "aws"
+	// LifecycleOnDemand string constant for On-Demand EC2 instances
 	LifecycleOnDemand = "on-demand"
-	LifecycleSpot     = "spot"
+	// LifecycleSpot string constant for Spot EC2 instances
+	LifecycleSpot = "spot"
 	// The AttachInstances API only supports adding 20 instances at a time
 	batchSize = 20
 )

--- a/pkg/cloudprovider/aws/aws.go
+++ b/pkg/cloudprovider/aws/aws.go
@@ -17,8 +17,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// ProviderName identifies this module as aws
-const ProviderName = "aws"
+const (
+	// ProviderName identifies this module as aws
+	ProviderName      = "aws"
+	LifecycleOnDemand = "on-demand"
+	LifecycleSpot     = "spot"
+	// The AttachInstances API only supports adding 20 instances at a time
+	batchSize = 20
+)
 
 func instanceToProviderID(instance *autoscaling.Instance) string {
 	return fmt.Sprintf("aws:///%s/%s", *instance.AvailabilityZone, *instance.InstanceId)
@@ -236,7 +242,7 @@ func (n *NodeGroup) IncreaseSize(delta int64) error {
 		return n.setASGDesiredSizeOneShot(delta)
 	}
 
-	log.WithField("asg", n.id).Infof("Scaling with SetDesiredCapacity trategy")
+	log.WithField("asg", n.id).Infof("Scaling with SetDesiredCapacity strategy")
 	return n.setASGDesiredSize(n.TargetSize() + delta)
 
 }
@@ -343,36 +349,27 @@ func (n *NodeGroup) setASGDesiredSize(newSize int64) error {
 // setASGDesiredSizeOneShot uses the AWS fleet API to acquire all desired
 // capacity in one step and then add it to the existing auto-scaling group.
 func (n *NodeGroup) setASGDesiredSizeOneShot(addCount int64) error {
-	fleet, err := n.provider.ec2Service.CreateFleet(&ec2.CreateFleetInput{
-		Type:                             awsapi.String("instant"),
-		TerminateInstancesWithExpiration: awsapi.Bool(false),
-		OnDemandOptions: &ec2.OnDemandOptionsRequest{
-			MinTargetCapacity:  awsapi.Int64(addCount),
-			SingleInstanceType: awsapi.Bool(true),
-		},
-		TargetCapacitySpecification: &ec2.TargetCapacitySpecificationRequest{
-			OnDemandTargetCapacity:    awsapi.Int64(addCount),
-			TotalTargetCapacity:       awsapi.Int64(addCount),
-			DefaultTargetCapacityType: awsapi.String("on-demand"),
-		},
-		LaunchTemplateConfigs: []*ec2.FleetLaunchTemplateConfigRequest{
-			{
-				LaunchTemplateSpecification: &ec2.FleetLaunchTemplateSpecificationRequest{
-					LaunchTemplateId: awsapi.String(n.config.AWSConfig.LaunchTemplateID),
-					Version:          awsapi.String(n.config.AWSConfig.LaunchTemplateVersion),
-				},
-			},
-		},
-	})
+	// Parse the Escalator args into the correct format for a CreateFleet request, then make the request.
+	fleetInput, err := createFleetInput(*n, addCount)
 	if err != nil {
+		log.Error("Failed setup for CreateFleet call.")
 		return err
 	}
 
-	// This will hold any launch errors for the fleet. In the case of an
-	// instant fleet with a single instant type this will indicate that the
-	// entire fleet failed to launch.
-	for _, lerr := range fleet.Errors {
-		return errors.New(*lerr.ErrorMessage)
+	fleet, err := n.provider.ec2Service.CreateFleet(fleetInput)
+	if err != nil {
+		log.Errorf("Failed CreateFleet call. CreateFleetInput: %v", fleetInput)
+		return err
+	}
+
+	// CreateFleet returns an array of errors with the response. Sometimes errors are present even when instances were
+	// successfully provisioned. In this case, the min target capacity is the size of the full request, so if any
+	// instances are present this indicates we got them all and can ignore the errors.
+	if len(fleet.Instances) == 0 && len(fleet.Errors) > 0 {
+		for _, err := range fleet.Errors {
+			log.Error(*err.ErrorMessage)
+		}
+		return errors.New(*fleet.Errors[0].ErrorMessage)
 	}
 
 	instances := make([]*string, 0)
@@ -402,8 +399,6 @@ InstanceReadyLoop:
 		}
 	}
 
-	// The AttachInstances API only supports adding 20 instances at a time
-	batchSize := 20
 	var batch []*string
 	for batchSize < len(instances) {
 		instances, batch = instances[batchSize:], instances[0:batchSize:batchSize]
@@ -413,6 +408,7 @@ InstanceReadyLoop:
 			InstanceIds:          batch,
 		})
 		if err != nil {
+			log.Error("Failed AttachInstances call.")
 			return err
 		}
 	}
@@ -426,7 +422,12 @@ InstanceReadyLoop:
 
 	log.WithField("asg", n.id).Debugf("CurrentSize: %v", n.Size())
 	log.WithField("asg", n.id).Debugf("CurrentTargetSize: %v", n.TargetSize())
-	return err
+	if err != nil {
+		log.Error("Failed AttachInstances call.")
+		return err
+	}
+
+	return nil
 }
 
 func (n *NodeGroup) allInstancesReady(ids []*string) bool {
@@ -452,4 +453,95 @@ func (n *NodeGroup) allInstancesReady(ids []*string) bool {
 	})
 
 	return ready
+}
+
+// createFleetInput will parse Escalator input into the format needed for a CreateFleet request.
+func createFleetInput(n NodeGroup, addCount int64) (*ec2.CreateFleetInput, error) {
+	lifecycle := n.config.AWSConfig.Lifecycle
+	if lifecycle == "" {
+		lifecycle = LifecycleOnDemand
+	}
+
+	launchTemplateOverrides, err := createTemplateOverrides(n)
+	if err != nil {
+		return nil, err
+	}
+
+	fleetInput := &ec2.CreateFleetInput{
+		Type:                             awsapi.String("instant"),
+		TerminateInstancesWithExpiration: awsapi.Bool(false),
+		TargetCapacitySpecification: &ec2.TargetCapacitySpecificationRequest{
+			TotalTargetCapacity:       awsapi.Int64(addCount),
+			DefaultTargetCapacityType: awsapi.String(lifecycle),
+		},
+		LaunchTemplateConfigs: []*ec2.FleetLaunchTemplateConfigRequest{
+			{
+				LaunchTemplateSpecification: &ec2.FleetLaunchTemplateSpecificationRequest{
+					LaunchTemplateId: awsapi.String(n.config.AWSConfig.LaunchTemplateID),
+					Version:          awsapi.String(n.config.AWSConfig.LaunchTemplateVersion),
+				},
+				Overrides: launchTemplateOverrides,
+			},
+		},
+	}
+
+	if lifecycle == LifecycleOnDemand {
+		fleetInput.OnDemandOptions = &ec2.OnDemandOptionsRequest{
+			MinTargetCapacity:  awsapi.Int64(addCount),
+			SingleInstanceType: awsapi.Bool(true),
+		}
+	} else {
+		fleetInput.SpotOptions = &ec2.SpotOptionsRequest{
+			MinTargetCapacity:  awsapi.Int64(addCount),
+			SingleInstanceType: awsapi.Bool(true),
+		}
+	}
+
+	return fleetInput, nil
+}
+
+// createTemplateOverrides will parse the overrides into the FleetLaunchTemplateOverridesRequest format
+func createTemplateOverrides(n NodeGroup) ([]*ec2.FleetLaunchTemplateOverridesRequest, error) {
+	// Get subnetIDs from the ASG
+	describeASGOutput, err := n.provider.service.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{
+		AutoScalingGroupNames: []*string{
+			awsapi.String(n.id),
+		},
+	})
+	if err != nil {
+		log.Errorf("Failed call to DescribeAutoScalingGroups for ASG %v", n.id)
+		return nil, err
+	}
+	if len(describeASGOutput.AutoScalingGroups) == 0 {
+		return nil, errors.New("failed to get an ASG from DescribeAutoscalingGroups response")
+	}
+	if *describeASGOutput.AutoScalingGroups[0].VPCZoneIdentifier == "" {
+		return nil, errors.New("failed to get any subnetIDs from DescribeAutoscalingGroups response")
+	}
+	vpcZoneIdentifier := describeASGOutput.AutoScalingGroups[0].VPCZoneIdentifier
+	subnetIDs := strings.Split(*vpcZoneIdentifier, ",")
+
+	instanceTypes := n.config.AWSConfig.InstanceTypeOverrides
+
+	var launchTemplateOverrides []*ec2.FleetLaunchTemplateOverridesRequest
+	if len(instanceTypes) > 0 {
+		for i := range subnetIDs {
+			for j := range instanceTypes {
+				overridesRequest := ec2.FleetLaunchTemplateOverridesRequest{
+					SubnetId:     &subnetIDs[i],
+					InstanceType: &instanceTypes[j],
+				}
+				launchTemplateOverrides = append(launchTemplateOverrides, &overridesRequest)
+			}
+		}
+	} else {
+		for i := range subnetIDs {
+			overridesRequest := ec2.FleetLaunchTemplateOverridesRequest{
+				SubnetId: &subnetIDs[i],
+			}
+			launchTemplateOverrides = append(launchTemplateOverrides, &overridesRequest)
+		}
+	}
+
+	return launchTemplateOverrides, nil
 }

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -1,7 +1,9 @@
 package aws
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/atlassian/escalator/pkg/cloudprovider"
 	"github.com/atlassian/escalator/pkg/test"
@@ -9,6 +11,45 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 	"github.com/stretchr/testify/assert"
 )
+
+// Arbitrarily longer than the Ticker timeout in setASGDesiredSizeOneShot
+const tickerTimeout = 2 * time.Second
+
+var (
+	mockASG             = autoscaling.Group{}
+	mockAWSConfig       = cloudprovider.AWSNodeGroupConfig{}
+	mockNodeGroup       = NodeGroup{}
+	mockNodeGroupConfig = cloudprovider.NodeGroupConfig{}
+)
+
+func setupAWSMocks() {
+	mockASG = autoscaling.Group{
+		AutoScalingGroupName: aws.String("asg-1"),
+		MaxSize:              aws.Int64(int64(25)),
+		DesiredCapacity:      aws.Int64(int64(1)),
+		VPCZoneIdentifier:    aws.String("subnetID-1,subnetID-2"),
+	}
+
+	mockAWSConfig = cloudprovider.AWSNodeGroupConfig{
+		LaunchTemplateID:          "lt-123456",
+		LaunchTemplateVersion:     "1",
+		FleetInstanceReadyTimeout: tickerTimeout,
+		Lifecycle:                 LifecycleOnDemand,
+		InstanceTypeOverrides:     []string{"instance-1", "instance-2"},
+	}
+
+	mockNodeGroup = NodeGroup{
+		id:     "id",
+		name:   "name",
+		config: &mockNodeGroupConfig,
+	}
+
+	mockNodeGroupConfig = cloudprovider.NodeGroupConfig{
+		Name:      "nodeGroupConfig",
+		GroupID:   "",
+		AWSConfig: mockAWSConfig,
+	}
+}
 
 func TestInstanceToProviderId(t *testing.T) {
 	instance := &autoscaling.Instance{
@@ -42,4 +83,154 @@ func newMockCloudProvider(nodeGroups []string, service *test.MockAutoscalingServ
 	}
 
 	return cloudProvider, err
+}
+
+// Similar to newMockCloudProvider but node groups are injected instead of created within this function
+func newMockCloudProviderUsingInjection(nodeGroups map[string]*NodeGroup, service *test.MockAutoscalingService, ec2Service *test.MockEc2Service) (*CloudProvider, error) {
+	var err error
+
+	cloudProvider := &CloudProvider{
+		service:    service,
+		ec2Service: ec2Service,
+		nodeGroups: nodeGroups,
+	}
+
+	for _, nodeGroup := range nodeGroups {
+		nodeGroup.provider = cloudProvider
+	}
+
+	return cloudProvider, err
+}
+
+func TestCreateFleetInput(t *testing.T) {
+	setupAWSMocks()
+	lifecycles := []string{"", LifecycleOnDemand, LifecycleSpot}
+	for _, lifecycle := range lifecycles {
+		autoScalingGroups := []*autoscaling.Group{&mockASG}
+		nodeGroups := map[string]*NodeGroup{mockNodeGroup.id: &mockNodeGroup}
+		addCount := int64(2)
+		mockAWSConfig.Lifecycle = lifecycle
+
+		awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+			nodeGroups,
+			&test.MockAutoscalingService{
+				DescribeAutoScalingGroupsOutput: &autoscaling.DescribeAutoScalingGroupsOutput{
+					AutoScalingGroups: autoScalingGroups,
+				},
+			},
+			&test.MockEc2Service{},
+		)
+		mockNodeGroup.provider = awsCloudProvider
+		mockNodeGroupConfig.AWSConfig = mockAWSConfig
+
+		_, err := createFleetInput(mockNodeGroup, addCount)
+		assert.Nil(t, err, "Expected no error from createFleetInput")
+	}
+}
+
+func TestCreateTemplateOverrides_FailedCall(t *testing.T) {
+	setupAWSMocks()
+	expectedError := errors.New("call failed")
+	nodeGroups := map[string]*NodeGroup{mockNodeGroup.id: &mockNodeGroup}
+
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nodeGroups,
+		&test.MockAutoscalingService{
+			DescribeAutoScalingGroupsOutput: &autoscaling.DescribeAutoScalingGroupsOutput{},
+			DescribeAutoScalingGroupsErr:    expectedError,
+		},
+		&test.MockEc2Service{},
+	)
+	mockNodeGroup.provider = awsCloudProvider
+
+	_, err := createTemplateOverrides(mockNodeGroup)
+	assert.Equal(t, expectedError, err, "Expected error with message '%v'", expectedError)
+}
+
+func TestCreateTemplateOverrides_NoASG(t *testing.T) {
+	setupAWSMocks()
+	var autoScalingGroups []*autoscaling.Group
+	nodeGroups := map[string]*NodeGroup{mockNodeGroup.id: &mockNodeGroup}
+
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nodeGroups,
+		&test.MockAutoscalingService{
+			DescribeAutoScalingGroupsOutput: &autoscaling.DescribeAutoScalingGroupsOutput{
+				AutoScalingGroups: autoScalingGroups,
+			},
+		},
+		&test.MockEc2Service{},
+	)
+	mockNodeGroup.provider = awsCloudProvider
+
+	_, error := createTemplateOverrides(mockNodeGroup)
+	errorMessage := "failed to get an ASG from DescribeAutoscalingGroups response"
+	e := errors.New(errorMessage)
+	assert.Equalf(t, e, error, "Expected error with message '%v'", errorMessage)
+}
+
+func TestCreateTemplateOverrides_NoSubnetIDs(t *testing.T) {
+	setupAWSMocks()
+	subnetIDs := ""
+	mockASG.VPCZoneIdentifier = &subnetIDs
+	autoScalingGroups := []*autoscaling.Group{&mockASG}
+	nodeGroups := map[string]*NodeGroup{mockNodeGroup.id: &mockNodeGroup}
+
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nodeGroups,
+		&test.MockAutoscalingService{
+			DescribeAutoScalingGroupsOutput: &autoscaling.DescribeAutoScalingGroupsOutput{
+				AutoScalingGroups: autoScalingGroups,
+			},
+		},
+		&test.MockEc2Service{},
+	)
+	mockNodeGroup.provider = awsCloudProvider
+
+	_, error := createTemplateOverrides(mockNodeGroup)
+	errorMessage := "failed to get any subnetIDs from DescribeAutoscalingGroups response"
+	e := errors.New(errorMessage)
+	assert.Equalf(t, e, error, "Expected error with message '%v'", errorMessage)
+}
+
+func TestCreateTemplateOverrides_Success(t *testing.T) {
+	setupAWSMocks()
+	autoScalingGroups := []*autoscaling.Group{&mockASG}
+	nodeGroups := map[string]*NodeGroup{mockNodeGroup.id: &mockNodeGroup}
+
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nodeGroups,
+		&test.MockAutoscalingService{
+			DescribeAutoScalingGroupsOutput: &autoscaling.DescribeAutoScalingGroupsOutput{
+				AutoScalingGroups: autoScalingGroups,
+			},
+		},
+		&test.MockEc2Service{},
+	)
+	mockNodeGroup.provider = awsCloudProvider
+
+	_, err := createTemplateOverrides(mockNodeGroup)
+	assert.Nil(t, err, "Expected no error from createTemplateOverrides")
+}
+
+func TestCreateTemplateOverrides_NoInstanceTypeOverrides_Success(t *testing.T) {
+	setupAWSMocks()
+	autoScalingGroups := []*autoscaling.Group{&mockASG}
+	nodeGroups := map[string]*NodeGroup{mockNodeGroup.id: &mockNodeGroup}
+
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nodeGroups,
+		&test.MockAutoscalingService{
+			DescribeAutoScalingGroupsOutput: &autoscaling.DescribeAutoScalingGroupsOutput{
+				AutoScalingGroups: autoScalingGroups,
+			},
+		},
+		&test.MockEc2Service{},
+	)
+	mockNodeGroup.provider = awsCloudProvider
+	mockAWSConfig.InstanceTypeOverrides = nil
+	mockNodeGroupConfig.AWSConfig = mockAWSConfig
+
+	_, err := createTemplateOverrides(mockNodeGroup)
+	assert.Nil(t, err, "Expected no error from createTemplateOverrides")
 }

--- a/pkg/cloudprovider/aws/node_group_test.go
+++ b/pkg/cloudprovider/aws/node_group_test.go
@@ -186,7 +186,7 @@ func TestNodeGroup_IncreaseSize(t *testing.T) {
 
 func TestNodeGroup_IncreaseSize_CreateFleet(t *testing.T) {
 	setupAWSMocks()
-	fleetId := "fleet-1234"
+	fleetID := "fleet-1234"
 	errorCode := "error code"
 	errorMessage := "error message"
 	instanceID := "instanceID"
@@ -207,7 +207,7 @@ func TestNodeGroup_IncreaseSize_CreateFleet(t *testing.T) {
 			int64(1),
 			&ec2.CreateFleetOutput{
 				Errors:  nil,
-				FleetId: &fleetId,
+				FleetId: &fleetID,
 				Instances: []*ec2.CreateFleetInstance{
 					{
 						InstanceIds: []*string{&instanceID},
@@ -228,7 +228,7 @@ func TestNodeGroup_IncreaseSize_CreateFleet(t *testing.T) {
 						ErrorMessage:               &errorMessage,
 					},
 				},
-				FleetId: &fleetId,
+				FleetId: &fleetID,
 				Instances: []*ec2.CreateFleetInstance{
 					{
 						InstanceIds: []*string{&instanceID},
@@ -249,7 +249,7 @@ func TestNodeGroup_IncreaseSize_CreateFleet(t *testing.T) {
 						ErrorMessage:               &errorMessage,
 					},
 				},
-				FleetId:   &fleetId,
+				FleetId:   &fleetID,
 				Instances: make([]*ec2.CreateFleetInstance, 0),
 			},
 			errors.New(errorMessage),
@@ -259,7 +259,7 @@ func TestNodeGroup_IncreaseSize_CreateFleet(t *testing.T) {
 			int64(multipleBatches),
 			&ec2.CreateFleetOutput{
 				Errors:  nil,
-				FleetId: &fleetId,
+				FleetId: &fleetID,
 				Instances: []*ec2.CreateFleetInstance{
 					{
 						InstanceIds: multipleBatchesInstanceIDs,

--- a/pkg/cloudprovider/interface.go
+++ b/pkg/cloudprovider/interface.go
@@ -115,4 +115,6 @@ type AWSNodeGroupConfig struct {
 	LaunchTemplateID          string
 	LaunchTemplateVersion     string
 	FleetInstanceReadyTimeout time.Duration
+	Lifecycle                 string
+	InstanceTypeOverrides     []string
 }

--- a/pkg/test/aws.go
+++ b/pkg/test/aws.go
@@ -26,7 +26,7 @@ type MockAutoscalingService struct {
 	TerminateInstanceInAutoScalingGroupErr    error
 }
 
-// AttachInstance mock implementation for MockAutoscalingService
+// AttachInstances mock implementation for MockAutoscalingService
 func (m MockAutoscalingService) AttachInstances(*autoscaling.AttachInstancesInput) (*autoscaling.AttachInstancesOutput, error) {
 	return m.AttachInstanceOutput, m.AttachInstanceErr
 }

--- a/pkg/test/aws.go
+++ b/pkg/test/aws.go
@@ -13,6 +13,9 @@ type MockAutoscalingService struct {
 	autoscalingiface.AutoScalingAPI
 	*client.Client
 
+	AttachInstanceOutput *autoscaling.AttachInstancesOutput
+	AttachInstanceErr    error
+
 	DescribeAutoScalingGroupsOutput *autoscaling.DescribeAutoScalingGroupsOutput
 	DescribeAutoScalingGroupsErr    error
 
@@ -21,6 +24,11 @@ type MockAutoscalingService struct {
 
 	TerminateInstanceInAutoScalingGroupOutput *autoscaling.TerminateInstanceInAutoScalingGroupOutput
 	TerminateInstanceInAutoScalingGroupErr    error
+}
+
+// AttachInstance mock implementation for MockAutoscalingService
+func (m MockAutoscalingService) AttachInstances(*autoscaling.AttachInstancesInput) (*autoscaling.AttachInstancesOutput, error) {
+	return m.AttachInstanceOutput, m.AttachInstanceErr
 }
 
 // DescribeAutoScalingGroups mock implementation for MockAutoscalingService
@@ -38,16 +46,34 @@ func (m MockAutoscalingService) TerminateInstanceInAutoScalingGroup(*autoscaling
 	return m.TerminateInstanceInAutoScalingGroupOutput, m.TerminateInstanceInAutoScalingGroupErr
 }
 
-// MockEc2Service mocks the EC2API for DescribeInstances
+// MockEc2Service mocks the EC2API
 type MockEc2Service struct {
 	ec2iface.EC2API
 	*client.Client
 
+	CreateFleetOutput *ec2.CreateFleetOutput
+	CreateFleetErr    error
+
 	DescribeInstancesOutput *ec2.DescribeInstancesOutput
 	DescribeInstancesErr    error
+
+	DescribeInstanceStatusOutput *ec2.DescribeInstanceStatusOutput
+	DescribeInstanceStatusErr    error
 }
 
-// DescribeInstances mock implementation for MockAutoscalingService
+// DescribeInstances mock implementation for MockEc2Service
 func (m MockEc2Service) DescribeInstances(*ec2.DescribeInstancesInput) (*ec2.DescribeInstancesOutput, error) {
 	return m.DescribeInstancesOutput, m.DescribeInstancesErr
+}
+
+// CreateFleet mock implementation for MockEc2Service
+func (m MockEc2Service) CreateFleet(*ec2.CreateFleetInput) (*ec2.CreateFleetOutput, error) {
+	return m.CreateFleetOutput, m.CreateFleetErr
+}
+
+// DescribeInstanceStatusPages mock implementation for MockEc2Service
+func (m MockEc2Service) DescribeInstanceStatusPages(statusInput *ec2.DescribeInstanceStatusInput, allInstancesReadyHelper func(*ec2.DescribeInstanceStatusOutput, bool) bool) error {
+	// Mocks successful execution of the anonymous function within cloudprovider/aws/aws.go:allInstancesReady
+	allInstancesReadyHelper(&ec2.DescribeInstanceStatusOutput{}, true)
+	return nil
 }


### PR DESCRIPTION
PR for issue #183

Adds two new optional parameters for when launch templates are used: Lifecycle and InstanceTypeOverrides. Then modifies the CreateFleet request based on these parameters to request either On Demand or Spot instances. Additionally makes a request to 'DescribeAutoScalingGroups' to get the subnet ids of the ASG. This ensures that requested instances are located in a correct subnet so that they can be attached to the cluster. Finally update the readme to correct the necessary IAM policy permissions. 