### PR TITLE
Fix the IAM Policy permissions

### DIFF
--- a/docs/deployment/aws/README.md
+++ b/docs/deployment/aws/README.md
@@ -18,14 +18,13 @@ Escalator requires the following IAM policy to be able to properly integrate wit
     {
       "Effect": "Allow",
       "Action": [
+        "autoscaling:AttachInstances",
         "autoscaling:DescribeAutoScalingGroups",
-        "autoscaling:DescribeAutoScalingInstances",
-        "autoscaling:DescribeLaunchConfigurations",
-        "autoscaling:DescribeTags",
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
-        "ec2:DescribeInstances",
-        "ec2:DescribeLaunchTemplateVersions"
+        "ec2:CreateFleet",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstances"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
The ReadMe has incorrect IAM Policy permissions. When I changed it in my last PR I submitted the IAM policy I use for cluster autoscaler instead of the one for Escalator 🤦‍♂️. All the permissions removed from here are the new ones I added in [that pr](https://github.com/atlassian/escalator/pull/188/files). 