### PR TITLE
Add tags to Auto Scaling Group and Fleet request

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,6 +77,7 @@ func setupCloudProvider(nodegroups []controller.NodeGroupOptions) cloudprovider.
 				FleetInstanceReadyTimeout: n.AWS.FleetInstanceReadyTimeoutDuration(),
 				Lifecycle:                 n.AWS.Lifecycle,
 				InstanceTypeOverrides:     n.AWS.InstanceTypeOverrides,
+				ResourceTagging:           n.AWS.ResourceTagging,
 			},
 		})
 	}

--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -32,6 +32,7 @@ node_groups:
         launch_template_id: "1"
         lifecycle: on-demand
         instance_type_overrides: ["t2.large", "t3.large"]
+        resource_tagging: false
 ```
 
 ## Options
@@ -242,3 +243,9 @@ Dependent on Launch Template ID being specified.
 An optional list of instance types to override the instance type within the launch template. Providing multiple instance
 types here increases the likelihood of a Spot request being successful. If omitted the instance type to request will
 be taken from the launch template.
+
+### `aws.resource_tagging`
+
+Tag ASG and Fleet Request resources used by Escalator with the metatdata key-value pair
+`k8s.io/atlassian-escalator/enabled`:`true`. Tagging doesn't alter the functionality of Escalator. Read more about
+tagging your AWS resources [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).

--- a/docs/deployment/aws/README.md
+++ b/docs/deployment/aws/README.md
@@ -19,6 +19,7 @@ Escalator requires the following IAM policy to be able to properly integrate wit
       "Effect": "Allow",
       "Action": [
         "autoscaling:AttachInstances",
+        "autoscaling:CreateOrUpdateTags",
         "autoscaling:DescribeAutoScalingGroups",
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",

--- a/pkg/cloudprovider/interface.go
+++ b/pkg/cloudprovider/interface.go
@@ -117,4 +117,5 @@ type AWSNodeGroupConfig struct {
 	FleetInstanceReadyTimeout time.Duration
 	Lifecycle                 string
 	InstanceTypeOverrides     []string
+	ResourceTagging           bool
 }

--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -59,6 +59,7 @@ type AWSNodeGroupOptions struct {
 	FleetInstanceReadyTimeout string   `json:"fleet_instance_ready_timeout,omitempty" yaml:"fleet_instance_ready_timeout,omitempty"`
 	Lifecycle                 string   `json:"lifecycle,omitempty" yaml:"lifecycle,omitempty"`
 	InstanceTypeOverrides     []string `json:"instance_type_overrides,omitempty" yaml:"instance_type_overrides,omitempty"`
+	ResourceTagging           bool     `json:"resource_tagging,omitempty" yaml:"resource_tagging,omitempty"`
 
 	// Private variables for storing the parsed duration from the string
 	fleetInstanceReadyTimeout time.Duration

--- a/pkg/test/aws.go
+++ b/pkg/test/aws.go
@@ -16,6 +16,9 @@ type MockAutoscalingService struct {
 	AttachInstanceOutput *autoscaling.AttachInstancesOutput
 	AttachInstanceErr    error
 
+	CreateOrUpdateTagsOutput *autoscaling.CreateOrUpdateTagsOutput
+	CreateOrUpdateTagsErr    error
+
 	DescribeAutoScalingGroupsOutput *autoscaling.DescribeAutoScalingGroupsOutput
 	DescribeAutoScalingGroupsErr    error
 
@@ -29,6 +32,11 @@ type MockAutoscalingService struct {
 // AttachInstances mock implementation for MockAutoscalingService
 func (m MockAutoscalingService) AttachInstances(*autoscaling.AttachInstancesInput) (*autoscaling.AttachInstancesOutput, error) {
 	return m.AttachInstanceOutput, m.AttachInstanceErr
+}
+
+// CreateOrUpdateTags mock implementation for MockAutoscalingService
+func (m MockAutoscalingService) CreateOrUpdateTags(*autoscaling.CreateOrUpdateTagsInput) (*autoscaling.CreateOrUpdateTagsOutput, error) {
+	return m.CreateOrUpdateTagsOutput, m.CreateOrUpdateTagsErr
 }
 
 // DescribeAutoScalingGroups mock implementation for MockAutoscalingService


### PR DESCRIPTION
[Tags](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html) are pieces of metadata customers can use to organize resources. They're particularly helpful to customers for breaking down costs, so they can see how much they're spending per tag. Functionally, they don't affect the performance of a resource in any way. 

This change checks the ASGs when the nodegroups are created to see if the escalator tag is present on the ASG. If the tag isn't present, a request is made to add the tag. The tag will propagate to any instances launched within the ASG, so instances created with either setDesiredCapacity or CreateFleet are tagged. 

Additionally, when CreateFleet is used the request itself is tagged. 

The tag names are arbitrary, but I had them follow the same style as the ones cluster autoscaler uses 