### PR TITLE
Terminate orphaned instances from CreateFleet requests

### DIFF
--- a/docs/deployment/aws/README.md
+++ b/docs/deployment/aws/README.md
@@ -24,8 +24,12 @@ Escalator requires the following IAM policy to be able to properly integrate wit
         "autoscaling:SetDesiredCapacity",
         "autoscaling:TerminateInstanceInAutoScalingGroup",
         "ec2:CreateFleet",
+        "ec2:CreateTags",
+        "ec2:DescribeInstances",
         "ec2:DescribeInstanceStatus",
-        "ec2:DescribeInstances"
+        "ec2:RunInstances",
+        "ec2:TerminateInstances",
+        "iam:PassRole"
       ],
       "Resource": "*"
     }

--- a/pkg/cloudprovider/aws/aws_test.go
+++ b/pkg/cloudprovider/aws/aws_test.go
@@ -2,8 +2,13 @@ package aws
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go/aws/client"
+	"github.com/aws/aws-sdk-go/service/autoscaling/autoscalingiface"
+	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
 	"github.com/atlassian/escalator/pkg/cloudprovider"
 	"github.com/atlassian/escalator/pkg/test"
@@ -45,6 +50,7 @@ func setupAWSMocks() {
 		id:     "id",
 		name:   "name",
 		config: &mockNodeGroupConfig,
+		asg:    &mockASG,
 	}
 
 	mockNodeGroupConfig = cloudprovider.NodeGroupConfig{
@@ -89,7 +95,7 @@ func newMockCloudProvider(nodeGroups []string, service *test.MockAutoscalingServ
 }
 
 // Similar to newMockCloudProvider but node groups are injected instead of created within this function
-func newMockCloudProviderUsingInjection(nodeGroups map[string]*NodeGroup, service *test.MockAutoscalingService, ec2Service *test.MockEc2Service) (*CloudProvider, error) {
+func newMockCloudProviderUsingInjection(nodeGroups map[string]*NodeGroup, service autoscalingiface.AutoScalingAPI, ec2Service ec2iface.EC2API) (*CloudProvider, error) {
 	var err error
 
 	cloudProvider := &CloudProvider{
@@ -322,6 +328,213 @@ func TestAddASGTags_WithErrorResponse(t *testing.T) {
 		&test.MockEc2Service{},
 	)
 	addASGTags(&mockNodeGroupConfig, &mockASG, awsCloudProvider)
+}
+
+// local mock of ASG service with custom AttachInstances method
+type mockAutoscalingService struct {
+	autoscalingiface.AutoScalingAPI
+	*client.Client
+
+	numCalls    int
+	numMaxCalls int
+}
+
+// fail the AttachInstances call after numMaxCalls have happened
+func (m *mockAutoscalingService) AttachInstances(*autoscaling.AttachInstancesInput) (*autoscaling.AttachInstancesOutput, error) {
+	if m.numCalls < m.numMaxCalls {
+		m.numCalls++
+		return &autoscaling.AttachInstancesOutput{}, nil
+	}
+	return &autoscaling.AttachInstancesOutput{}, fmt.Errorf("failed the AttachInstances call")
+}
+
+func TestAttachInstancesToASG_WithInstanceReadyTimeout_ExpectFailure(t *testing.T) {
+	setupAWSMocks()
+	instanceID := "instanceID"
+
+	numInstances := 123
+	var instanceIDs []*string
+	for i := 0; i < numInstances; i++ {
+		instanceIDs = append(instanceIDs, &instanceID)
+	}
+
+	// Mock service call and error
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nil,
+		&mockAutoscalingService{
+			AutoScalingAPI: nil,
+			Client:         nil,
+			numCalls:       0,
+			numMaxCalls:    2,
+		},
+		&test.MockEc2Service{
+			TerminateInstancesOutput: &ec2.TerminateInstancesOutput{},
+			TerminateInstancesErr:    nil,
+			AllInstancesReady:        false,
+		},
+	)
+
+	mockNodeGroup.provider = awsCloudProvider
+
+	// assert the terminate function is called with the correct number of instances
+	mockTerminateFunc := func(n *NodeGroup, i []*string) {
+		assert.Equal(t, numInstances, len(i))
+	}
+
+	err := mockNodeGroup.attachInstancesToASG(instanceIDs, mockTerminateFunc)
+	assert.Error(t, err)
+}
+
+func TestAttachInstancesToASG_NoSuccessfulBatches_ExpectFailure(t *testing.T) {
+	setupAWSMocks()
+	instanceID := "instanceID"
+
+	terminateSize := 50
+	numInstances := batchSize + terminateSize
+	var instanceIDs []*string
+	for i := 0; i < numInstances; i++ {
+		instanceIDs = append(instanceIDs, &instanceID)
+	}
+
+	// Mock service call and error
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nil,
+		&mockAutoscalingService{
+			AutoScalingAPI: nil,
+			Client:         nil,
+			numCalls:       0,
+			numMaxCalls:    0,
+		},
+		&test.MockEc2Service{
+			TerminateInstancesOutput: &ec2.TerminateInstancesOutput{},
+			TerminateInstancesErr:    nil,
+			AllInstancesReady:        true,
+		},
+	)
+
+	mockNodeGroup.provider = awsCloudProvider
+
+	// assert the terminate function is called with the correct number of instances
+	mockTerminateFunc := func(n *NodeGroup, i []*string) {
+		assert.Equal(t, numInstances, len(i), "Expected all instances to be terminated")
+	}
+
+	err := mockNodeGroup.attachInstancesToASG(instanceIDs, mockTerminateFunc)
+	assert.Error(t, err)
+}
+
+func TestAttachInstancesToASG_OneSuccessfulBatch_ExpectFailure(t *testing.T) {
+	setupAWSMocks()
+	instanceID := "instanceID"
+
+	terminateSize := 50
+	numInstances := batchSize + terminateSize
+	var instanceIDs []*string
+	for i := 0; i < numInstances; i++ {
+		instanceIDs = append(instanceIDs, &instanceID)
+	}
+
+	// Mock service call and error
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nil,
+		&mockAutoscalingService{
+			AutoScalingAPI: nil,
+			Client:         nil,
+			numCalls:       0,
+			numMaxCalls:    1,
+		},
+		&test.MockEc2Service{
+			TerminateInstancesOutput: &ec2.TerminateInstancesOutput{},
+			TerminateInstancesErr:    nil,
+			AllInstancesReady:        true,
+		},
+	)
+
+	mockNodeGroup.provider = awsCloudProvider
+
+	// assert the terminate function is called with the correct number of instances
+	mockTerminateFunc := func(n *NodeGroup, i []*string) {
+		assert.Equal(t, terminateSize, len(i), "Expected all instances except the first batch to be terminated")
+	}
+
+	err := mockNodeGroup.attachInstancesToASG(instanceIDs, mockTerminateFunc)
+	assert.Error(t, err)
+}
+
+func TestAttachInstancesToASG_NoBatches_ExpectFailure(t *testing.T) {
+	setupAWSMocks()
+	instanceID := "instanceID"
+
+	terminateSize := batchSize - 1
+	numInstances := terminateSize
+	var instanceIDs []*string
+	for i := 0; i < numInstances; i++ {
+		instanceIDs = append(instanceIDs, &instanceID)
+	}
+
+	// Mock service call and error
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		nil,
+		&mockAutoscalingService{
+			AutoScalingAPI: nil,
+			Client:         nil,
+			numCalls:       0,
+			numMaxCalls:    0,
+		},
+		&test.MockEc2Service{
+			TerminateInstancesOutput: &ec2.TerminateInstancesOutput{},
+			TerminateInstancesErr:    nil,
+			AllInstancesReady:        true,
+		},
+	)
+
+	mockNodeGroup.provider = awsCloudProvider
+
+	// assert the terminate function is called with the correct number of instances
+	mockTerminateFunc := func(n *NodeGroup, i []*string) {
+		assert.Equal(t, terminateSize, len(i))
+	}
+
+	err := mockNodeGroup.attachInstancesToASG(instanceIDs, mockTerminateFunc)
+	assert.Error(t, err)
+}
+
+func TestAttachInstancesToASG_ExpectSuccess(t *testing.T) {
+	setupAWSMocks()
+	instanceID := "instanceID"
+
+	terminateSize := batchSize - 1
+	numInstances := terminateSize
+	var instanceIDs []*string
+	for i := 0; i < numInstances; i++ {
+		instanceIDs = append(instanceIDs, &instanceID)
+	}
+
+	// Mock service call and error
+	awsCloudProvider, _ := newMockCloudProviderUsingInjection(
+		map[string]*NodeGroup{mockNodeGroup.id: &mockNodeGroup},
+		&mockAutoscalingService{
+			AutoScalingAPI: nil,
+			Client:         nil,
+			numCalls:       0,
+			numMaxCalls:    1,
+		},
+		&test.MockEc2Service{
+			TerminateInstancesOutput: &ec2.TerminateInstancesOutput{},
+			TerminateInstancesErr:    nil,
+			AllInstancesReady:        true,
+		},
+	)
+
+	mockNodeGroup.provider = awsCloudProvider
+
+	// the terminate function shouldn't get called - fail the test if it does
+	mockTerminateFunc := func(n *NodeGroup, i []*string) {
+		assert.Fail(t, "No instances should have been terminated")
+	}
+
+	err := mockNodeGroup.attachInstancesToASG(instanceIDs, mockTerminateFunc)
+	assert.NoError(t, err)
 }
 
 func TestTerminateInstances_Success(t *testing.T) {

--- a/pkg/cloudprovider/aws/node_group_test.go
+++ b/pkg/cloudprovider/aws/node_group_test.go
@@ -294,6 +294,7 @@ func TestNodeGroup_IncreaseSize_CreateFleet(t *testing.T) {
 				&test.MockEc2Service{
 					CreateFleetOutput:       tt.createFleetOutput,
 					DescribeInstancesOutput: &ec2.DescribeInstancesOutput{},
+					AllInstancesReady:       true,
 				},
 			)
 

--- a/pkg/test/aws.go
+++ b/pkg/test/aws.go
@@ -67,6 +67,9 @@ type MockEc2Service struct {
 
 	DescribeInstanceStatusOutput *ec2.DescribeInstanceStatusOutput
 	DescribeInstanceStatusErr    error
+
+	TerminateInstancesOutput *ec2.TerminateInstancesOutput
+	TerminateInstancesErr    error
 }
 
 // DescribeInstances mock implementation for MockEc2Service
@@ -84,4 +87,9 @@ func (m MockEc2Service) DescribeInstanceStatusPages(statusInput *ec2.DescribeIns
 	// Mocks successful execution of the anonymous function within cloudprovider/aws/aws.go:allInstancesReady
 	allInstancesReadyHelper(&ec2.DescribeInstanceStatusOutput{}, true)
 	return nil
+}
+
+// TerminateInstances mock implementation for MockEc2Service
+func (m MockEc2Service) TerminateInstances(*ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error) {
+	return m.TerminateInstancesOutput, m.TerminateInstancesErr
 }

--- a/pkg/test/aws.go
+++ b/pkg/test/aws.go
@@ -67,6 +67,7 @@ type MockEc2Service struct {
 
 	DescribeInstanceStatusOutput *ec2.DescribeInstanceStatusOutput
 	DescribeInstanceStatusErr    error
+	AllInstancesReady            bool
 
 	TerminateInstancesOutput *ec2.TerminateInstancesOutput
 	TerminateInstancesErr    error
@@ -84,8 +85,8 @@ func (m MockEc2Service) CreateFleet(*ec2.CreateFleetInput) (*ec2.CreateFleetOutp
 
 // DescribeInstanceStatusPages mock implementation for MockEc2Service
 func (m MockEc2Service) DescribeInstanceStatusPages(statusInput *ec2.DescribeInstanceStatusInput, allInstancesReadyHelper func(*ec2.DescribeInstanceStatusOutput, bool) bool) error {
-	// Mocks successful execution of the anonymous function within cloudprovider/aws/aws.go:allInstancesReady
-	allInstancesReadyHelper(&ec2.DescribeInstanceStatusOutput{}, true)
+	// Mocks execution of the anonymous function within cloudprovider/aws/aws.go:allInstancesReady
+	allInstancesReadyHelper(&ec2.DescribeInstanceStatusOutput{}, m.AllInstancesReady)
 	return nil
 }
 


### PR DESCRIPTION
When using CreateFleet to provision new instances, there's a chance that instances are returned from the call but then not attached to the ASG. Instances that are not attached to the ASG will never be terminated by Esclator, so they'll stay running in the user's account indefinitely. This happens in two cases:
1. When not all instances are in a "ready" state before the instance ready timeout is hit. In this case the full number of instances become orphaned
1. When a call to AttachInstances fails. In this case any instances that haven't been attached to the instance become orphaned (happens in batches of 20)

Here's a screenshot of this happening to me for this scenario:
- 1 instance was requested but failed to be ready before the timeout
- next loop 1 instance was requested and was ready in time and attached to the ASG
- 5 instances were requested but at least one wasn't ready in time
- 5 instances were requested and successfully attached to the ASG
- When my job was finished half of the instances did not terminate
<img width="812" alt="image" src="https://user-images.githubusercontent.com/56001173/94935197-5a339b80-0492-11eb-8d32-4adecb705571.png">


This change handles these cases and calls TerminateInstances with the list of instances that haven't been attached to the ASG. To try and mitigate the issue of these failures happening indefinitely, say if the timeout value is too low, a fatal is logged if this happens three times in a row. 