### PR TITLE
consider initContainers when calculating a pod's requests

### DIFF
--- a/pkg/k8s/resource/quantity.go
+++ b/pkg/k8s/resource/quantity.go
@@ -1,0 +1,17 @@
+package resource
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func NewMemoryQuantity(value int64) *resource.Quantity {
+	return resource.NewQuantity(value, resource.BinarySI)
+}
+
+func NewCPUQuantity(value int64) *resource.Quantity {
+	return resource.NewMilliQuantity(value, resource.DecimalSI)
+}
+
+func NewPodQuantity(value int64) *resource.Quantity {
+	return resource.NewQuantity(value, resource.DecimalSI)
+}

--- a/pkg/k8s/scheduler/types.go
+++ b/pkg/k8s/scheduler/types.go
@@ -1,0 +1,96 @@
+package scheduler
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+// Resource is a collection of compute resource.
+type Resource struct {
+	MilliCPU         int64
+	Memory           int64
+}
+
+// Add adds ResourceList into Resource.
+func (r *Resource) Add(rl v1.ResourceList) {
+	if r == nil {
+		return
+	}
+
+	for rName, rQuant := range rl {
+		switch rName {
+		case v1.ResourceCPU:
+			r.MilliCPU += rQuant.MilliValue()
+		case v1.ResourceMemory:
+			r.Memory += rQuant.Value()
+		}
+	}
+}
+
+// SetMaxResource compares with ResourceList and takes max value for each Resource.
+func (r *Resource) SetMaxResource(rl v1.ResourceList) {
+	if r == nil {
+		return
+	}
+
+	for rName, rQuantity := range rl {
+		switch rName {
+		case v1.ResourceMemory:
+			r.Memory = max(r.Memory, rQuantity.Value())
+		case v1.ResourceCPU:
+			r.MilliCPU = max(r.MilliCPU, rQuantity.MilliValue())
+		}
+	}
+}
+
+// ComputePodResourceRequest returns a framework.Resource that covers the largest
+// width in each resource dimension. Because init-containers run sequentially, we collect
+// the max in each dimension iteratively. In contrast, we sum the resource vectors for
+// regular containers since they run simultaneously.
+//
+// If Pod Overhead is specified, the resources defined for Overhead
+// are added to the calculated Resource request sum
+//
+// Example:
+//
+// Pod:
+//   InitContainers
+//     IC1:
+//       CPU: 2
+//       Memory: 1G
+//     IC2:
+//       CPU: 2
+//       Memory: 3G
+//   Containers
+//     C1:
+//       CPU: 2
+//       Memory: 1G
+//     C2:
+//       CPU: 1
+//       Memory: 1G
+//
+// Result: CPU: 3, Memory: 3G
+func ComputePodResourceRequest(pod *v1.Pod) *Resource {
+	resource := &Resource{}
+	for _, container := range pod.Spec.Containers {
+		resource.Add(container.Resources.Requests)
+	}
+
+	// take max_resource(sum_pod, any_init_container)
+	for _, container := range pod.Spec.InitContainers {
+		resource.SetMaxResource(container.Resources.Requests)
+	}
+
+	// If Overhead is being utilized, add to the total requests for the pod
+	if pod.Spec.Overhead != nil {
+		resource.Add(pod.Spec.Overhead)
+	}
+
+	return resource
+}
+
+func max(a, b int64) int64 {
+	if a >= b {
+		return a
+	}
+	return b
+}

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -1,6 +1,8 @@
 package k8s
 
 import (
+	k8s_resource "github.com/atlassian/escalator/pkg/k8s/resource"
+	"github.com/atlassian/escalator/pkg/k8s/scheduler"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -23,19 +25,13 @@ func PodIsStatic(pod *v1.Pod) bool {
 
 // CalculatePodsRequestsTotal returns the total capacity of all pods
 func CalculatePodsRequestsTotal(pods []*v1.Pod) (resource.Quantity, resource.Quantity, error) {
-	var memoryRequests resource.Quantity
-	var cpuRequests resource.Quantity
+	memoryRequests := *k8s_resource.NewMemoryQuantity(0)
+	cpuRequests := *k8s_resource.NewCPUQuantity(0)
 
-	// todo: what about initContainers? what happens if the requests from the initContainers is larger than the containers?
 	for _, pod := range pods {
-		// Include the pod overhead, if configured
-		memoryRequests.Add(*pod.Spec.Overhead.Memory())
-		cpuRequests.Add(*pod.Spec.Overhead.Cpu())
-
-		for _, container := range pod.Spec.Containers {
-			memoryRequests.Add(*container.Resources.Requests.Memory())
-			cpuRequests.Add(*container.Resources.Requests.Cpu())
-		}
+		podResources := scheduler.ComputePodResourceRequest(pod)
+		memoryRequests.Add(*k8s_resource.NewMemoryQuantity(podResources.Memory))
+		cpuRequests.Add(*k8s_resource.NewCPUQuantity(podResources.MilliCPU))
 	}
 
 	return memoryRequests, cpuRequests, nil
@@ -43,8 +39,8 @@ func CalculatePodsRequestsTotal(pods []*v1.Pod) (resource.Quantity, resource.Qua
 
 // CalculateNodesCapacityTotal calculates the total Allocatable node capacity for all nodes
 func CalculateNodesCapacityTotal(nodes []*v1.Node) (resource.Quantity, resource.Quantity, error) {
-	var memoryCapacity resource.Quantity
-	var cpuCapacity resource.Quantity
+	memoryCapacity := *k8s_resource.NewMemoryQuantity(0)
+	cpuCapacity := *k8s_resource.NewCPUQuantity(0)
 
 	for _, node := range nodes {
 		memoryCapacity.Add(*node.Status.Allocatable.Memory())


### PR DESCRIPTION
This commit also:
 - Standardises uses of resource.Quantity
 - Adds expectedNodeDelta to scale up tests

fixes #202