### PR TITLE
Default Pod Selector ignores Pods with affinity set to empty struct

### DIFF
--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -268,7 +268,9 @@ func NewPodDefaultFilterFunc() k8s.PodFilterFunc {
 		// Only include pods that pass the following:
 		// - Don't have a nodeSelector
 		// - Don't have an affinity
-		return len(pod.Spec.NodeSelector) == 0 && pod.Spec.Affinity == nil
+		return len(pod.Spec.NodeSelector) == 0 && (pod.Spec.Affinity == nil ||
+			(pod.Spec.Affinity.NodeAffinity == nil && pod.Spec.Affinity.PodAffinity == nil &&
+				pod.Spec.Affinity.PodAntiAffinity == nil))
 	}
 }
 


### PR DESCRIPTION
Some solutions such as Gitlab Runner (https://gitlab.com/gitlab-org/gitlab-runner/-/blob/main/common/config.go#L1093) if affinity is not especially set via configs will produce Pods with `affinity: {}`. 

In this case expression `pod.Spec.Affinity == nil` is not valid, and Affinity is equal to `&Affinity{NodeAffinity:nil,PodAffinity:nil,PodAntiAffinity:nil,}`.

Affinity is still not set, so condition for Default Pod Selector is still met, however escalator will ignore such pods.

My PR extends `NewPodDefaultFilterFunc()` fixing this.