### PR TITLE
KUBE-5984 - ensure that scale-ups always occur when there are starved pods

### DIFF
--- a/docs/calculations.md
+++ b/docs/calculations.md
@@ -84,6 +84,13 @@ when cached capacity exists:
 when cached capacity doesn't exist:
 - Amount to increase by: `1` node
 
+## Scale On Starve
+
+The node groups can also contain an optional boolean parameter `scale_on_starve`. When this is true, the system caps
+each escalation size to a minimum of 1 whenever there is a pod that cannot currently be scheduled. This helps alleviate
+situations where a large pod exceeds the available capacity of any 1 node, but its total size does not cause the system
+as a whole to exceed the scale up threshold.
+
 
 ## Daemonsets
 

--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -16,6 +16,7 @@ node_groups:
     min_nodes: 1
     max_nodes: 30
     dry_mode: false
+    scale_on_starve: false
     taint_upper_capacity_threshold_percent: 40
     taint_lower_capacity_threshold_percent: 10
     slow_node_removal_rate: 2
@@ -97,6 +98,14 @@ the node group, but just logs out the actions it would perform. This is helpful 
 Escalator would do in specific scenarios.
 
 Note: this flag is overridden by the `--drymode` command line flag.
+
+### `scale_on_starve`
+
+This flag adds an additional check to the escalator scaling algorithm to enforce a minimum scaling of 1 new node
+whenever there is a pod that cannot currently be scheduled due to no node having capacity to run it.
+
+Warning: You have to be extra careful around pod request sizes not exceeding node capacity when this option is enabled,
+or you may find the escalator always creates the maximum number of nodes.
 
 ### `taint_upper_capacity_threshold_percent`
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -275,6 +275,14 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	metrics.NodeGroupCPUCapacity.WithLabelValues(nodegroup).Set(float64(nodeCapacity.Total.GetCPUQuantity().MilliValue()))
 	metrics.NodeGroupMemCapacity.WithLabelValues(nodegroup).Set(float64(nodeCapacity.Total.GetMemoryQuantity().MilliValue() / 1000))
 	metrics.NodeGroupMemRequest.WithLabelValues(nodegroup).Set(float64(podRequests.Total.GetMemoryQuantity().MilliValue() / 1000))
+	metrics.NodeGroupCPURequestLargestPendingCPU.WithLabelValues(nodegroup).Set(float64(podRequests.LargestPendingCPU.GetCPUQuantity().MilliValue()))
+	metrics.NodeGroupMemRequestLargestPendingCPU.WithLabelValues(nodegroup).Set(float64(podRequests.LargestPendingCPU.GetMemoryQuantity().MilliValue() / 1000))
+	metrics.NodeGroupCPURequestLargestPendingMem.WithLabelValues(nodegroup).Set(float64(podRequests.LargestPendingMemory.GetCPUQuantity().MilliValue()))
+	metrics.NodeGroupMemRequestLargestPendingMem.WithLabelValues(nodegroup).Set(float64(podRequests.LargestPendingMemory.GetMemoryQuantity().MilliValue() / 1000))
+	metrics.NodeGroupCPUCapacityLargestAvailableCPU.WithLabelValues(nodegroup).Set(float64(nodeCapacity.LargestAvailableCPU.GetCPUQuantity().MilliValue()))
+	metrics.NodeGroupMemCapacityLargestAvailableCPU.WithLabelValues(nodegroup).Set(float64(nodeCapacity.LargestAvailableCPU.GetMemoryQuantity().MilliValue() / 1000))
+	metrics.NodeGroupCPUCapacityLargestAvailableMem.WithLabelValues(nodegroup).Set(float64(nodeCapacity.LargestAvailableMemory.GetCPUQuantity().MilliValue()))
+	metrics.NodeGroupMemCapacityLargestAvailableMem.WithLabelValues(nodegroup).Set(float64(nodeCapacity.LargestAvailableMemory.GetMemoryQuantity().MilliValue() / 1000))
 
 	// If we ever get into a state where we have less nodes than the minimum
 	if len(untaintedNodes) < nodeGroup.Opts.MinNodes {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -361,8 +361,9 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	}
 
 	if nodeGroup.Opts.ScaleOnStarve &&
-		podRequests.LargestCPU.MilliCPU > nodeCapacity.LargestAvailableCPU.MilliCPU ||
-		podRequests.LargestMemory.Memory > nodeCapacity.LargestAvailableMemory.Memory {
+		(podRequests.LargestCPU.MilliCPU > nodeCapacity.LargestAvailableCPU.MilliCPU ||
+			podRequests.LargestMemory.Memory > nodeCapacity.LargestAvailableMemory.Memory) &&
+		len(untaintedNodes) < nodeGroup.Opts.MaxNodes {
 		log.WithField("nodegroup", nodegroup).Info("Setting scale to minimum of 1 due to a starved pod")
 		nodesDelta = int(math.Max(float64(nodesDelta), 1))
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -361,8 +361,8 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	}
 
 	if nodeGroup.Opts.ScaleOnStarve &&
-		(podRequests.LargestCPU.MilliCPU > nodeCapacity.LargestAvailableCPU.MilliCPU ||
-			podRequests.LargestMemory.Memory > nodeCapacity.LargestAvailableMemory.Memory) &&
+		((!podRequests.LargestPendingCPU.IsEmpty() && podRequests.LargestPendingCPU.MilliCPU > nodeCapacity.LargestAvailableCPU.MilliCPU) ||
+			(!podRequests.LargestPendingMemory.IsEmpty() && podRequests.LargestPendingMemory.Memory > nodeCapacity.LargestAvailableMemory.Memory)) &&
 		len(untaintedNodes) < nodeGroup.Opts.MaxNodes {
 		log.WithField("nodegroup", nodegroup).Info("Setting scale to minimum of 1 due to a starved pod")
 		nodesDelta = int(math.Max(float64(nodesDelta), 1))

--- a/pkg/controller/controller_scale_node_group_test.go
+++ b/pkg/controller/controller_scale_node_group_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	duration "time"
 
+	"github.com/atlassian/escalator/pkg/k8s"
 	"github.com/atlassian/escalator/pkg/k8s/resource"
 	"github.com/atlassian/escalator/pkg/test"
 	"github.com/pkg/errors"
@@ -561,17 +562,27 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 	memArgs := int64(1000)
 
 	nodes := buildTestNodes(5, 1000, 1000)
-	pods := make([]*v1.Pod, 0, 51)
-	pods = append(pods, test.BuildTestPods(50, test.PodOpts{
+	pods := test.BuildTestPods(50, test.PodOpts{
 		CPU:      []int64{50},
 		Mem:      []int64{50},
 		NodeName: nodes[0].Name,
 		Running:  true,
 		Phase:    v1.PodPending,
-	})...)
+	})
+	no_pods := make([]*v1.Pod, 0)
+	scale_down_pods := test.BuildTestPods(10, test.PodOpts{
+		CPU:      []int64{50},
+		Mem:      []int64{50},
+		NodeName: nodes[0].Name,
+		Running:  true,
+		Phase:    v1.PodPending,
+	})
 	for i := 0; i < 5; i++ {
 		for j := 0; j < 10; j++ {
 			pods[i*10+j].Spec.NodeName = nodes[i].Name
+		}
+		for j := 0; j < 2; j++ {
+			scale_down_pods[i*2+j].Spec.NodeName = nodes[i].Name
 		}
 	}
 	pods = append(pods, test.BuildTestPod(test.PodOpts{
@@ -580,12 +591,18 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 		Phase:   v1.PodPending,
 		Running: false,
 	}))
-	log.Infof("Total pods: %d", len(pods))
+	scale_down_pods = append(scale_down_pods, test.BuildTestPod(test.PodOpts{
+		CPU:     []int64{950},
+		Mem:     []int64{950},
+		Phase:   v1.PodPending,
+		Running: false,
+	}))
 
 	tests := []struct {
 		name              string
 		args              args
 		expectedNodeDelta int
+		checkSecond       bool
 		err               error
 	}{
 		{
@@ -604,6 +621,7 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 				ListerOptions{},
 			},
 			1,
+			true,
 			nil,
 		},
 		{
@@ -622,6 +640,7 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 				ListerOptions{},
 			},
 			0,
+			true,
 			nil,
 		},
 		{
@@ -640,6 +659,68 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 				ListerOptions{},
 			},
 			0,
+			true,
+			nil,
+		},
+		{
+			"We don't scale up when no pods exist",
+			args{
+				nodes,
+				no_pods,
+				NodeGroupOptions{
+					Name:                    "default",
+					CloudProviderGroupName:  "default",
+					MinNodes:                2,
+					MaxNodes:                10,
+					ScaleUpThresholdPercent: 70,
+					ScaleOnStarve:           true,
+				},
+				ListerOptions{},
+			},
+			0,
+			true,
+			nil,
+		},
+		{
+			"Scale down with ScaleOnStarve disabled (but starved pod) still scales down",
+			args{
+				nodes,
+				scale_down_pods,
+				NodeGroupOptions{
+					Name:                               "default",
+					CloudProviderGroupName:             "default",
+					MinNodes:                           2,
+					MaxNodes:                           10,
+					ScaleUpThresholdPercent:            70,
+					ScaleOnStarve:                      false,
+					TaintUpperCapacityThresholdPercent: 40,
+					SlowNodeRemovalRate:                1,
+				},
+				ListerOptions{},
+			},
+			-1,
+			true,
+			nil,
+		},
+		{
+			"Scale down with ScaleOnStarve enabled (and starved pod) still scales up",
+			args{
+				nodes,
+				scale_down_pods,
+				NodeGroupOptions{
+					Name:                               "default",
+					CloudProviderGroupName:             "default",
+					MinNodes:                           2,
+					MaxNodes:                           10,
+					ScaleUpThresholdPercent:            70,
+					ScaleOnStarve:                      true,
+					TaintUpperCapacityThresholdPercent: 40,
+					SlowNodeRemovalRate:                1,
+				},
+				ListerOptions{},
+			},
+			1,
+			false, // second run will scale down instead of neutral
 			nil,
 		},
 	}
@@ -650,6 +731,11 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 			ngName := tt.args.nodeGroupOptions.Name
 			client, opts, err := buildTestClient(tt.args.nodes, tt.args.pods, nodeGroups, tt.args.listerOptions)
 			require.NoError(t, err)
+			// Reset node taints from previous tests
+			for _, node := range tt.args.nodes {
+				_, err := k8s.DeleteToBeRemovedTaint(node, client)
+				require.NoError(t, err)
+			}
 
 			// For these test cases we only use 1 node group/cloud provider node group
 			nodeGroupSize := 1
@@ -698,17 +784,19 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 
 			// Create the nodes to simulate the cloud provider bringing up the new nodes
 			newNodes := append(nodes, buildTestNodes(nodesDelta, cpuArgs, memArgs)...)
-			// Create a new client with the new nodes and update everything that uses the client
-			client, opts, err = buildTestClient(newNodes, tt.args.pods, nodeGroups, tt.args.listerOptions)
-			require.NoError(t, err)
+			if tt.checkSecond {
+				// Create a new client with the new nodes and update everything that uses the client
+				client, opts, err = buildTestClient(newNodes, tt.args.pods, nodeGroups, tt.args.listerOptions)
+				require.NoError(t, err)
 
-			controller.Client = client
-			controller.Opts = opts
-			nodeGroupsState[ngName].NodeGroupLister = client.Listers[ngName]
+				controller.Client = client
+				controller.Opts = opts
+				nodeGroupsState[ngName].NodeGroupLister = client.Listers[ngName]
 
-			// Re-run the scale, ensure the result is 0 as we shouldn't need to scale up again
-			newNodesDelta, _ := controller.scaleNodeGroup(ngName, nodeGroupsState[ngName])
-			assert.Equal(t, 0, newNodesDelta)
+				// Re-run the scale, ensure the result is 0 as we shouldn't need to scale up again
+				newNodesDelta, _ := controller.scaleNodeGroup(ngName, nodeGroupsState[ngName])
+				assert.Equal(t, 0, newNodesDelta)
+			}
 
 		})
 	}

--- a/pkg/controller/controller_scale_node_group_test.go
+++ b/pkg/controller/controller_scale_node_group_test.go
@@ -562,15 +562,13 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 
 	nodes := buildTestNodes(5, 1000, 1000)
 	pods := make([]*v1.Pod, 0, 51)
-	for _, pod := range test.BuildTestPods(50, test.PodOpts{
+	pods = append(pods, test.BuildTestPods(50, test.PodOpts{
 		CPU:      []int64{50},
 		Mem:      []int64{50},
 		NodeName: nodes[0].Name,
 		Running:  true,
 		Phase:    v1.PodPending,
-	}) {
-		pods = append(pods, pod)
-	}
+	})...)
 	for i := 0; i < 5; i++ {
 		for j := 0; j < 10; j++ {
 			pods[i*10+j].Spec.NodeName = nodes[i].Name
@@ -623,7 +621,7 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 				},
 				ListerOptions{},
 			},
-			1,
+			0,
 			nil,
 		},
 		{
@@ -637,11 +635,11 @@ func TestScaleNodeGroupScaleOnStarve(t *testing.T) {
 					MinNodes:                2,
 					MaxNodes:                5,
 					ScaleUpThresholdPercent: 70,
-					ScaleOnStarve:           false,
+					ScaleOnStarve:           true,
 				},
 				ListerOptions{},
 			},
-			1,
+			0,
 			nil,
 		},
 	}

--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -28,6 +28,8 @@ type NodeGroupOptions struct {
 
 	DryMode bool `json:"dry_mode,omitempty" yaml:"dry_mode,omitempty"`
 
+	ScaleOnStarve bool `json:"scale_on_starve,omitempty" yaml:"scale_on_starve,omitempty"`
+
 	TaintUpperCapacityThresholdPercent int `json:"taint_upper_capacity_threshold_percent,omitempty" yaml:"taint_upper_capacity_threshold_percent,omitempty"`
 	TaintLowerCapacityThresholdPercent int `json:"taint_lower_capacity_threshold_percent,omitempty" yaml:"taint_lower_capacity_threshold_percent,omitempty"`
 

--- a/pkg/k8s/scheduler/types.go
+++ b/pkg/k8s/scheduler/types.go
@@ -1,13 +1,29 @@
 package scheduler
 
 import (
+	k8s_resource "github.com/atlassian/escalator/pkg/k8s/resource"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Resource is a collection of compute resource.
 type Resource struct {
-	MilliCPU         int64
-	Memory           int64
+	MilliCPU int64
+	Memory   int64
+}
+
+func NewEmptyResource() Resource {
+	return Resource{
+		MilliCPU: 0,
+		Memory:   0,
+	}
+}
+
+func NewResource(cpu int64, memory int64) Resource {
+	return Resource{
+		MilliCPU: cpu,
+		Memory:   memory,
+	}
 }
 
 // Add adds ResourceList into Resource.
@@ -24,6 +40,14 @@ func (r *Resource) Add(rl v1.ResourceList) {
 			r.Memory += rQuant.Value()
 		}
 	}
+}
+
+func (r *Resource) GetCPUQuantity() *resource.Quantity {
+	return k8s_resource.NewCPUQuantity(r.MilliCPU)
+}
+
+func (r *Resource) GetMemoryQuantity() *resource.Quantity {
+	return k8s_resource.NewMemoryQuantity(r.Memory)
 }
 
 // SetMaxResource compares with ResourceList and takes max value for each Resource.
@@ -53,20 +77,21 @@ func (r *Resource) SetMaxResource(rl v1.ResourceList) {
 // Example:
 //
 // Pod:
-//   InitContainers
-//     IC1:
-//       CPU: 2
-//       Memory: 1G
-//     IC2:
-//       CPU: 2
-//       Memory: 3G
-//   Containers
-//     C1:
-//       CPU: 2
-//       Memory: 1G
-//     C2:
-//       CPU: 1
-//       Memory: 1G
+//
+//	InitContainers
+//	  IC1:
+//	    CPU: 2
+//	    Memory: 1G
+//	  IC2:
+//	    CPU: 2
+//	    Memory: 3G
+//	Containers
+//	  C1:
+//	    CPU: 2
+//	    Memory: 1G
+//	  C2:
+//	    CPU: 1
+//	    Memory: 1G
 //
 // Result: CPU: 3, Memory: 3G
 func ComputePodResourceRequest(pod *v1.Pod) *Resource {

--- a/pkg/k8s/scheduler/types.go
+++ b/pkg/k8s/scheduler/types.go
@@ -50,6 +50,10 @@ func (r *Resource) GetMemoryQuantity() *resource.Quantity {
 	return k8s_resource.NewMemoryQuantity(r.Memory)
 }
 
+func (r *Resource) IsEmpty() bool {
+	return r.MilliCPU == 0 && r.Memory == 0
+}
+
 // SetMaxResource compares with ResourceList and takes max value for each Resource.
 func (r *Resource) SetMaxResource(rl v1.ResourceList) {
 	if r == nil {

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -1,11 +1,37 @@
 package k8s
 
 import (
-	k8s_resource "github.com/atlassian/escalator/pkg/k8s/resource"
 	"github.com/atlassian/escalator/pkg/k8s/scheduler"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 )
+
+type PodRequestedUsage struct {
+	Total         scheduler.Resource
+	LargestMemory scheduler.Resource
+	LargestCPU    scheduler.Resource
+}
+
+type NodeAvailableCapacity struct {
+	Total                  scheduler.Resource
+	LargestAvailableMemory scheduler.Resource
+	LargestAvailableCPU    scheduler.Resource
+}
+
+func newPodRequestedUsage() PodRequestedUsage {
+	return PodRequestedUsage{
+		Total:         scheduler.NewEmptyResource(),
+		LargestMemory: scheduler.NewEmptyResource(),
+		LargestCPU:    scheduler.NewEmptyResource(),
+	}
+}
+
+func newNodeAvailableCapacity() NodeAvailableCapacity {
+	return NodeAvailableCapacity{
+		Total:                  scheduler.NewEmptyResource(),
+		LargestAvailableMemory: scheduler.NewEmptyResource(),
+		LargestAvailableCPU:    scheduler.NewEmptyResource(),
+	}
+}
 
 // PodIsDaemonSet returns if the pod is a daemonset or not
 func PodIsDaemonSet(pod *v1.Pod) bool {
@@ -23,29 +49,111 @@ func PodIsStatic(pod *v1.Pod) bool {
 	return ok && configSource == "file"
 }
 
-// CalculatePodsRequestsTotal returns the total capacity of all pods
-func CalculatePodsRequestsTotal(pods []*v1.Pod) (resource.Quantity, resource.Quantity, error) {
-	memoryRequests := *k8s_resource.NewMemoryQuantity(0)
-	cpuRequests := *k8s_resource.NewCPUQuantity(0)
+// CalculatePodsRequestedUsage returns the total capacity of all pods
+func CalculatePodsRequestedUsage(pods []*v1.Pod) (PodRequestedUsage, error) {
+	ret := newPodRequestedUsage()
 
 	for _, pod := range pods {
 		podResources := scheduler.ComputePodResourceRequest(pod)
-		memoryRequests.Add(*k8s_resource.NewMemoryQuantity(podResources.Memory))
-		cpuRequests.Add(*k8s_resource.NewCPUQuantity(podResources.MilliCPU))
+		ret.Total.Memory += podResources.Memory
+		ret.Total.MilliCPU += podResources.MilliCPU
+		if pod.Status.Phase == v1.PodPending {
+			if podResources.Memory > ret.LargestMemory.Memory {
+				ret.LargestMemory = scheduler.NewResource(podResources.MilliCPU, podResources.Memory)
+			}
+			if podResources.MilliCPU > ret.LargestCPU.MilliCPU {
+				ret.LargestCPU = scheduler.NewResource(podResources.MilliCPU, podResources.Memory)
+			}
+		}
 	}
 
-	return memoryRequests, cpuRequests, nil
+	return ret, nil
 }
 
-// CalculateNodesCapacityTotal calculates the total Allocatable node capacity for all nodes
-func CalculateNodesCapacityTotal(nodes []*v1.Node) (resource.Quantity, resource.Quantity, error) {
-	memoryCapacity := *k8s_resource.NewMemoryQuantity(0)
-	cpuCapacity := *k8s_resource.NewCPUQuantity(0)
+// CalculateNodesCapacity calculates the total Allocatable node capacity for all nodes
+func CalculateNodesCapacity(nodes []*v1.Node, pods []*v1.Pod) (NodeAvailableCapacity, error) {
+	ret := newNodeAvailableCapacity()
 
+	mappedPods := mapPodsToNode(pods)
 	for _, node := range nodes {
-		memoryCapacity.Add(*node.Status.Allocatable.Memory())
-		cpuCapacity.Add(*node.Status.Allocatable.Cpu())
+		ret.Total.Memory += node.Status.Allocatable.Memory().Value()
+		ret.Total.MilliCPU += node.Status.Allocatable.Cpu().MilliValue()
+		availableResource := getNodeAvailableResources(node, mappedPods)
+		if availableResource.MilliCPU > ret.LargestAvailableCPU.MilliCPU {
+			ret.LargestAvailableCPU = scheduler.NewResource(
+				availableResource.MilliCPU,
+				availableResource.Memory,
+			)
+		}
+		if availableResource.Memory > ret.LargestAvailableMemory.Memory {
+			ret.LargestAvailableMemory = scheduler.NewResource(
+				availableResource.MilliCPU,
+				availableResource.Memory,
+			)
+		}
 	}
 
-	return memoryCapacity, cpuCapacity, nil
+	return ret, nil
+}
+
+// Hashes pods to their assigned nodes (via pod.Spec.NodeName), allowing quicker lookup later
+func mapPodsToNode(pods []*v1.Pod) map[string]([]*v1.Pod) {
+	ret := make(map[string]([]*v1.Pod))
+	for _, pod := range pods {
+		name := pod.Spec.NodeName
+		val, found := ret[name]
+		if !found {
+			ret[name] = make([]*v1.Pod, 0)
+			val = ret[name]
+		}
+		ret[name] = append(val, pod)
+	}
+	return ret
+}
+
+// Map each pod with f then reduce with sum. Also checks the Pod is relevant to the node.
+func sumPodResourceWithFunc(pods []*v1.Pod, f func(*v1.Pod) int64) int64 {
+	ret := int64(0)
+	for _, pod := range pods {
+		if isPodUsingNodeResources(pod) {
+			ret += f(pod)
+		}
+	}
+	return ret
+}
+
+// Determine if a pod has the PodScheduled condition as true
+func isPodScheduled(pod *v1.Pod) bool {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == v1.PodScheduled {
+			return condition.Status == v1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// Determine if we should count a pod as using a node's resources for starvation calculations
+func isPodUsingNodeResources(pod *v1.Pod) bool {
+	return isPodScheduled(pod) &&
+		(pod.Status.Phase == v1.PodPending || pod.Status.Phase == v1.PodRunning)
+}
+
+// Calculate how much free CPU/Memory a given node has
+// Subtracts the requested pod usage of every assigned pod from the allocated resources
+func getNodeAvailableResources(node *v1.Node, pods map[string]([]*v1.Pod)) scheduler.Resource {
+	filteredPods := pods[node.Name]
+	usedCpu := sumPodResourceWithFunc(filteredPods, func(pod *v1.Pod) int64 {
+		podResources := scheduler.ComputePodResourceRequest(pod)
+		return podResources.MilliCPU
+	})
+	usedMemory := sumPodResourceWithFunc(
+		filteredPods, func(pod *v1.Pod) int64 {
+			podResources := scheduler.ComputePodResourceRequest(pod)
+			return podResources.Memory
+		},
+	)
+	return scheduler.NewResource(
+		node.Status.Allocatable.Cpu().MilliValue()-usedCpu,
+		node.Status.Allocatable.Memory().Value()-usedMemory,
+	)
 }

--- a/pkg/k8s/util_test.go
+++ b/pkg/k8s/util_test.go
@@ -60,36 +60,36 @@ func TestCalculatePodsRequestTotal(t *testing.T) {
 		Mem: []int64{225, 100, 430, 1000},
 	})
 	p8 := test.BuildTestPod(test.PodOpts{
-		CPU: []int64{22, 60, 430, 1000},
-		Mem: []int64{225, 100, 430, 1000},
+		CPU:         []int64{22, 60, 430, 1000},
+		Mem:         []int64{225, 100, 430, 1000},
 		CPUOverhead: 1000,
 		MemOverhead: 2000,
 	})
 	p9 := test.BuildTestPod(test.PodOpts{
-		CPU: []int64{100, 200, 300},
-		Mem: []int64{100, 100, 100},
+		CPU:         []int64{100, 200, 300},
+		Mem:         []int64{100, 100, 100},
 		CPUOverhead: 10000,
 		MemOverhead: 3000,
 	})
 	p10 := test.BuildTestPod(test.PodOpts{
 		InitContainersCPU: []int64{20000},
 		InitContainersMem: []int64{500},
-		CPU: []int64{100, 200, 300},
-		Mem: []int64{100, 100, 100},
+		CPU:               []int64{100, 200, 300},
+		Mem:               []int64{100, 100, 100},
 	})
 	p11 := test.BuildTestPod(test.PodOpts{
 		InitContainersCPU: []int64{100},
 		InitContainersMem: []int64{500},
-		CPU: []int64{100, 200, 300},
-		Mem: []int64{100, 100, 100},
+		CPU:               []int64{100, 200, 300},
+		Mem:               []int64{100, 100, 100},
 	})
 	p12 := test.BuildTestPod(test.PodOpts{
 		InitContainersCPU: []int64{20000},
 		InitContainersMem: []int64{500},
-		CPU: []int64{100, 200, 300},
-		Mem: []int64{100, 100, 100},
-		CPUOverhead: 10000,
-		MemOverhead: 3000,
+		CPU:               []int64{100, 200, 300},
+		Mem:               []int64{100, 100, 100},
+		CPUOverhead:       10000,
+		MemOverhead:       3000,
 	})
 
 	type args struct {
@@ -208,17 +208,17 @@ func TestCalculatePodsRequestTotal(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mem, cpu, err := k8s.CalculatePodsRequestsTotal(tt.args.pods)
+			podRequests, err := k8s.CalculatePodsRequestedUsage(tt.args.pods)
 			expectedMem := *resource.NewMemoryQuantity(tt.mem)
 			expectedCPU := *resource.NewCPUQuantity(tt.cpu)
-			assert.Equal(t, expectedMem, mem)
-			assert.Equal(t, expectedCPU, cpu)
+			assert.Equal(t, expectedMem, *podRequests.Total.GetMemoryQuantity())
+			assert.Equal(t, expectedCPU, *podRequests.Total.GetCPUQuantity())
 			assert.NoError(t, err)
 		})
 	}
 }
 
-func TestCalculateNodesCapacityTotal(t *testing.T) {
+func TestCalculateNodesCapacity(t *testing.T) {
 	n1 := test.BuildTestNode(test.NodeOpts{
 		CPU: 1000,
 		Mem: 1000,
@@ -310,9 +310,9 @@ func TestCalculateNodesCapacityTotal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			expectedCpu := *resource.NewCPUQuantity(tt.cpu)
 			expectedMem := *resource.NewMemoryQuantity(tt.mem)
-			mem, cpu, err := k8s.CalculateNodesCapacityTotal(tt.args.nodes)
-			assert.Equal(t, expectedMem, mem)
-			assert.Equal(t, expectedCpu, cpu)
+			nodeCapacity, err := k8s.CalculateNodesCapacity(tt.args.nodes, make([]*v1.Pod, 0))
+			assert.Equal(t, expectedMem, *nodeCapacity.Total.GetMemoryQuantity())
+			assert.Equal(t, expectedCpu, *nodeCapacity.Total.GetCPUQuantity())
 			assert.NoError(t, err)
 		})
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -108,6 +108,42 @@ var (
 		},
 		[]string{"node_group"},
 	)
+	// NodeGroupMemRequestLargestPendingCPU byte value of memory of node group's largest pod by request CPU
+	NodeGroupMemRequestLargestPendingCPU = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_mem_request_largest_pending_cpu",
+			Namespace: NAMESPACE,
+			Help:      "byte value of memory for largest pending pod by cpu",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupCPURequestLargestPendingCPU milli value of CPU of node group's largest pod by request cpu
+	NodeGroupCPURequestLargestPendingCPU = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_cpu_request_largest_pending_cpu",
+			Namespace: NAMESPACE,
+			Help:      "milli value of cpu for largest pending pod by cpu",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupMemRequestLargestPendingMem byte value of memory of node group's largest pod by request Mem
+	NodeGroupMemRequestLargestPendingMem = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_mem_request_largest_pending_mem",
+			Namespace: NAMESPACE,
+			Help:      "byte value of memory for largest pending pod by memory",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupCPURequestLargestPendingMem milli value of CPU of node group's largest pod by request Mem
+	NodeGroupCPURequestLargestPendingMem = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_cpu_request_largest_pending_mem",
+			Namespace: NAMESPACE,
+			Help:      "milli value of cpu for largest pending pod by memory",
+		},
+		[]string{"node_group"},
+	)
 	// NodeGroupMemCapacity byte value of node capacity mem
 	NodeGroupMemCapacity = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -123,6 +159,42 @@ var (
 			Name:      "node_group_cpu_capacity",
 			Namespace: NAMESPACE,
 			Help:      "milli value of node capacity cpu",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupMemCapacityLargestAvailableCPU byte value of available memory of node group's largest node by available CPU
+	NodeGroupMemCapacityLargestAvailableCPU = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_mem_capacity_largest_available_cpu",
+			Namespace: NAMESPACE,
+			Help:      "byte value of memory capacity for largest available node by cpu",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupCPUCapacityLargestAvailableCPU milli value of available CPU of node group's largest node by available cpu
+	NodeGroupCPUCapacityLargestAvailableCPU = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_cpu_capacity_largest_available_cpu",
+			Namespace: NAMESPACE,
+			Help:      "milli value of cpu capacity for largest available node by cpu",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupMemCapacityLargestAvailableMem byte value of available memory of node group's largest node by available Mem
+	NodeGroupMemCapacityLargestAvailableMem = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_mem_capacity_largest_available_mem",
+			Namespace: NAMESPACE,
+			Help:      "byte value of memory capacity for largest available node by memory",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupCPUCapacityLargestAvailableMem milli value of available CPU of node group's largest node by available Mem
+	NodeGroupCPUCapacityLargestAvailableMem = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_cpu_capacity_largest_available_mem",
+			Namespace: NAMESPACE,
+			Help:      "milli value of cpu capacity for largest available node by memory",
 		},
 		[]string{"node_group"},
 	)
@@ -241,8 +313,16 @@ func init() {
 	prometheus.MustRegister(NodeGroupsCPUPercent)
 	prometheus.MustRegister(NodeGroupCPURequest)
 	prometheus.MustRegister(NodeGroupMemRequest)
+	prometheus.MustRegister(NodeGroupCPURequestLargestPendingCPU)
+	prometheus.MustRegister(NodeGroupMemRequestLargestPendingCPU)
+	prometheus.MustRegister(NodeGroupCPURequestLargestPendingMem)
+	prometheus.MustRegister(NodeGroupMemRequestLargestPendingMem)
 	prometheus.MustRegister(NodeGroupCPUCapacity)
 	prometheus.MustRegister(NodeGroupMemCapacity)
+	prometheus.MustRegister(NodeGroupCPUCapacityLargestAvailableCPU)
+	prometheus.MustRegister(NodeGroupMemCapacityLargestAvailableCPU)
+	prometheus.MustRegister(NodeGroupCPUCapacityLargestAvailableMem)
+	prometheus.MustRegister(NodeGroupMemCapacityLargestAvailableMem)
 	prometheus.MustRegister(NodeGroupTaintEvent)
 	prometheus.MustRegister(NodeGroupUntaintEvent)
 	prometheus.MustRegister(NodeGroupScaleLock)

--- a/pkg/test/builder.go
+++ b/pkg/test/builder.go
@@ -174,6 +174,8 @@ type PodOpts struct {
 	MemOverhead       int64
 	InitContainersCPU []int64
 	InitContainersMem []int64
+	Phase             v1.PodPhase
+	Running           bool
 }
 
 // BuildTestPod builds a pod for testing
@@ -281,6 +283,12 @@ func BuildTestPod(opts PodOpts) *apiv1.Pod {
 			pod.Spec.InitContainers[i].Resources.Requests[apiv1.ResourceMemory] = *resource.NewMemoryQuantity(opts.InitContainersMem[i])
 		}
 	}
+
+	conditions := make([]v1.PodCondition, 0)
+	if opts.Running {
+		conditions = append(conditions, v1.PodCondition{Type: v1.PodScheduled, Status: v1.ConditionTrue})
+	}
+	pod.Status = v1.PodStatus{Phase: opts.Phase, Conditions: conditions}
 
 	return pod
 }


### PR DESCRIPTION
This fixes https://github.com/atlassian/escalator/issues/224

The main change here is to add a `ScaleOnStarve` option to the node group configuration. This true/false value configures an additional check on the nodeDelta calculated during the scaling step. 

When we gather the RequestedPod, we also gather the largest pending pods (by both CPU and Memory). When we gather the node capacity, we also gather the largest node (node with allocatable CPU/Memory minus used pod CPU/memory) that is the highest. If either of the requested pods have larger requirements than what's available on the largest capacity, then that indicates we have a "starved pod". In the case that a pod exists with no nodes available (and we have `ScaleOnStarve` enabled), then we make sure that the scaling algorithm has at least 1 scale up as the final result.