### PR TITLE
Dockerfile: Set default value for buildarg ENVVAR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM golang:1.20 as builder
 ARG TARGETPLATFORM
-ARG ENVVAR
+ARG ENVVAR=CGO_ENABLED=0
 WORKDIR /go/src/github.com/atlassian/escalator/
 COPY go.mod go.sum Makefile ./
 COPY cmd cmd


### PR DESCRIPTION
Make sure CGO_ENABLED=0 is used when build the Alpine based container images.