### PR TITLE
add the ability to remove nodes older than a certain age even when the node group has reached the min

### DIFF
--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -27,6 +27,7 @@ node_groups:
     soft_delete_grace_period: 1m
     hard_delete_grace_period: 10m
     taint_effect: NoExecute
+    max_node_age: 24h
     aws:
         fleet_instance_ready_timeout: 1m
         launch_template_id: lt-1a2b3c4d
@@ -258,3 +259,17 @@ be taken from the launch template.
 Tag ASG and Fleet Request resources used by Escalator with the metatdata key-value pair
 `k8s.io/atlassian-escalator/enabled`:`true`. Tagging doesn't alter the functionality of Escalator. Read more about
 tagging your AWS resources [here](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html).
+
+### `max_node_age`
+
+`max_node_age` allows the configuration of a maximum age for nodes in the node group when the node group has scaled down
+to the minimum node group size. When at the minimum node grop size, Escalator will trigger a scale up by a minimum of 1
+if there are any nodes exceeding this max node age in an effort to have the old node rotated out.
+
+This is to ensure that nodes in the node group are kept relatively new to pick up any changes to the launch
+configuration or launch template.
+
+When not at the minimum, the natural scaling up and down of the node group will ensure new nodes are introduced to the
+node group.
+
+This is an optional feature and by default is disabled.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -373,6 +373,12 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 		nodesDelta = int(math.Max(float64(nodesDelta), 1))
 	}
 
+	if c.scaleOnMaxNodeAge(nodeGroup, untaintedNodes) {
+		log.WithField("nodegroup", nodegroup).
+			Info("Setting scale to minimum of 1 to rotate out a node older than the max node age")
+		nodesDelta = int(math.Max(float64(nodesDelta), 1))
+	}
+
 	log.WithField("nodegroup", nodegroup).Debugf("Delta: %v", nodesDelta)
 
 	scaleOptions := scaleOpts{
@@ -429,6 +435,33 @@ func (c *Controller) isScaleOnStarve(
 		((!podRequests.LargestPendingCPU.IsEmpty() && podRequests.LargestPendingCPU.MilliCPU > nodeCapacity.LargestAvailableCPU.MilliCPU) ||
 			(!podRequests.LargestPendingMemory.IsEmpty() && podRequests.LargestPendingMemory.Memory > nodeCapacity.LargestAvailableMemory.Memory)) &&
 		len(untaintedNodes) < nodeGroup.Opts.MaxNodes
+}
+
+// scaleOnMaxNodeAge returns true if the node group is at the minimum and there is a node in the untaintedNodes older
+// than the configured node group's maxNodeAge. The idea here is to constantly rotate out the oldest nodes
+// when the node group is at the minimum. This is to ensure the nodes are receiving the most up-to-date configuration
+// from the cloud provider.
+func (c *Controller) scaleOnMaxNodeAge(nodeGroup *NodeGroupState, untaintedNodes []*v1.Node) bool {
+	// Only enable this functionality if the node group has the feature enabled
+	if nodeGroup.Opts.MaxNodeAgeDuration() <= 0 {
+		return false
+	}
+
+	// We don't want to attempt to rotate nodes that have reached the max age if we haven't reached the minimum node
+	// count, as the scaling down of the node group will remove the oldest first anyway.
+	if len(untaintedNodes) != nodeGroup.Opts.MinNodes || len(untaintedNodes) == 0 {
+		return false
+	}
+
+	// Determine if there is an untainted node that exceeds the max age, if so then we should scale up
+	// to trigger that node to be replaced.
+	for _, n := range untaintedNodes {
+		if time.Since(n.CreationTimestamp.Time) > nodeGroup.Opts.MaxNodeAgeDuration() {
+			return true
+		}
+	}
+
+	return false
 }
 
 // RunOnce performs the main autoscaler logic once

--- a/pkg/controller/controller_scale_node_group_test.go
+++ b/pkg/controller/controller_scale_node_group_test.go
@@ -1212,6 +1212,45 @@ func TestScaleNodeGroupNodeMaxAge(t *testing.T) {
 			0,
 			nil,
 		},
+		{
+			"max_node_age enabled, scaled down to zero",
+			args{
+				nodes: []*v1.Node{},
+				pods: nil,
+				nodeGroupOptions: NodeGroupOptions{
+					Name:                    "default",
+					CloudProviderGroupName:  "default",
+					MinNodes:                0,
+					MaxNodes:                10,
+					ScaleUpThresholdPercent: 70,
+					MaxNodeAge:              "12h",
+				},
+				listerOptions: ListerOptions{},
+			},
+			0,
+			nil,
+		},
+		{
+			"max_node_age enabled, 1 tainted, 1 untainted",
+			args{
+				nodes: []*v1.Node{
+					buildNode(time.Now().Add(-1*stdtime.Hour), false),
+					buildNode(time.Now().Add(-24*stdtime.Hour), true),
+				},
+				pods: nil,
+				nodeGroupOptions: NodeGroupOptions{
+					Name:                    "default",
+					CloudProviderGroupName:  "default",
+					MinNodes:                1,
+					MaxNodes:                10,
+					ScaleUpThresholdPercent: 70,
+					MaxNodeAge:              "30m",
+				},
+				listerOptions: ListerOptions{},
+			},
+			0,
+			nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/test/builder.go
+++ b/pkg/test/builder.go
@@ -102,6 +102,9 @@ func NameFromChan(c <-chan string, timeout time.Duration) string {
 
 // BuildTestNode creates a node with specified capacity.
 func BuildTestNode(opts NodeOpts) *apiv1.Node {
+	if opts.Name == "" {
+		opts.Name = uuid.New().String()
+	}
 
 	var taints []apiv1.Taint
 	if opts.Tainted {


### PR DESCRIPTION
- adds max_node_age field to node group configuration
- max_node_age by default is disabled, and needs to be a positive, greater than zero duration to enable
- when the node group has reached the minimum and there are nodes older than the max_node_age, the scale delta will be set to +1
- this will then force escalator to replace the oldest node

fixes #239