### PR TITLE
Implement Force Removal Taint Logic

### DIFF
--- a/docs/node-termination.md
+++ b/docs/node-termination.md
@@ -52,3 +52,15 @@ metadata:
   annotations:
     atlassian.com/no-delete: "testing some long running bpf tracing"
 ```
+
+## Force Tainting
+
+Force Tainting provides a mechanism for Escalator to promptly remove nodes tainted by an external system, or administrator.
+
+This is implemented by applying a taint to the node, with the following key:
+
+```
+atlassian.com/escalator-force
+```
+
+The node will be removed as soon as all non-daemonset pods are completed. This is useful when nodes must be removed asap, but running pods should not be killed.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -143,15 +143,16 @@ func (c *Controller) filterNodes(nodeGroup *NodeGroupState, allNodes []*v1.Node)
 				cordonedNodes = append(cordonedNodes, node)
 				continue
 			}
-			var _, tainted = k8s.GetToBeRemovedTaint(node)
+
 			var _, forceTainted = k8s.GetToBeForceRemovedTaint(node)
-			if tainted {
-				taintedNodes = append(taintedNodes, node)
-			}
+			var _, tainted = k8s.GetToBeRemovedTaint(node)
+			var untainted = !forceTainted && !tainted
+
 			if forceTainted {
 				forceTaintedNodes = append(forceTaintedNodes, node)
-			}
-			if !tainted && !forceTainted {
+			} else if tainted {
+				taintedNodes = append(taintedNodes, node)
+			} else if untainted {
 				untaintedNodes = append(untaintedNodes, node)
 			}
 		}

--- a/pkg/controller/controller_scale_node_group_test.go
+++ b/pkg/controller/controller_scale_node_group_test.go
@@ -126,7 +126,7 @@ func TestUntaintNodeGroupMinNodes(t *testing.T) {
 		_, err = controller.scaleNodeGroup(nodeGroup.Name, nodeGroupsState[nodeGroup.Name])
 		assert.NoError(t, err)
 
-		untainted, tainted, _ := controller.filterNodes(nodeGroupsState[nodeGroup.Name], nodes)
+		untainted, tainted, _, _ := controller.filterNodes(nodeGroupsState[nodeGroup.Name], nodes)
 		// Ensure that the tainted nodes where untainted
 		assert.Equal(t, minNodes, len(untainted))
 		assert.Equal(t, 0, len(tainted))
@@ -193,7 +193,7 @@ func TestUntaintNodeGroupMaxNodes(t *testing.T) {
 		_, err = controller.scaleNodeGroup(nodeGroup.Name, nodeGroupsState[nodeGroup.Name])
 		require.NoError(t, err)
 
-		untainted, tainted, _ := controller.filterNodes(nodeGroupsState[nodeGroup.Name], nodes)
+		untainted, tainted, _, _ := controller.filterNodes(nodeGroupsState[nodeGroup.Name], nodes)
 		// Ensure that the tainted nodes where untainted
 		assert.Equal(t, maxNodes, len(untainted))
 		assert.Equal(t, 0, len(tainted))

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -147,7 +147,8 @@ func TestControllerFilterNodes(t *testing.T) {
 					Opts: NodeGroupOptions{
 						DryMode: true,
 					},
-					taintTracker: []string{"n1", "n3", "n5"},
+					taintTracker:      []string{"n1", "n3", "n5"},
+					forceTaintTracker: []string{"n7"},
 				},
 				nodes,
 				true,

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -105,6 +105,10 @@ func TestControllerFilterNodes(t *testing.T) {
 			Name:    "n6",
 			Tainted: false,
 		}),
+		6: test.BuildTestNode(test.NodeOpts{
+			Name:         "n7",
+			ForceTainted: true,
+		}),
 	}
 
 	type args struct {
@@ -113,11 +117,12 @@ func TestControllerFilterNodes(t *testing.T) {
 		master    bool
 	}
 	tests := []struct {
-		name               string
-		args               args
-		wantUntaintedNodes []*v1.Node
-		wantTaintedNodes   []*v1.Node
-		wantCordonedNodes  []*v1.Node
+		name                  string
+		args                  args
+		wantUntaintedNodes    []*v1.Node
+		wantTaintedNodes      []*v1.Node
+		wantForceTaintedNodes []*v1.Node
+		wantCordonedNodes     []*v1.Node
 	}{
 		{
 			"basic filter not drymode",
@@ -132,6 +137,7 @@ func TestControllerFilterNodes(t *testing.T) {
 			},
 			[]*v1.Node{nodes[1], nodes[3], nodes[5]},
 			[]*v1.Node{nodes[0], nodes[2], nodes[4]},
+			[]*v1.Node{nodes[6]},
 			[]*v1.Node{},
 		},
 		{
@@ -148,6 +154,7 @@ func TestControllerFilterNodes(t *testing.T) {
 			},
 			[]*v1.Node{nodes[1], nodes[3], nodes[5]},
 			[]*v1.Node{nodes[0], nodes[2], nodes[4]},
+			[]*v1.Node{nodes[6]},
 			[]*v1.Node{},
 		},
 	}
@@ -158,9 +165,10 @@ func TestControllerFilterNodes(t *testing.T) {
 					DryMode: tt.args.master,
 				},
 			}
-			gotUntaintedNodes, gotTaintedNodes, gotCordonedNodes := c.filterNodes(tt.args.nodeGroup, tt.args.allNodes)
+			gotUntaintedNodes, gotTaintedNodes, gotForceTaintedNodes, gotCordonedNodes := c.filterNodes(tt.args.nodeGroup, tt.args.allNodes)
 			assert.Equal(t, tt.wantUntaintedNodes, gotUntaintedNodes)
 			assert.Equal(t, tt.wantTaintedNodes, gotTaintedNodes)
+			assert.Equal(t, tt.wantForceTaintedNodes, gotForceTaintedNodes)
 			assert.Equal(t, tt.wantCordonedNodes, gotCordonedNodes)
 		})
 	}

--- a/pkg/controller/scale_down_test.go
+++ b/pkg/controller/scale_down_test.go
@@ -87,6 +87,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 				scaleOpts{
 					nodes,
 					[]*v1.Node{},
+					[]*v1.Node{},
 					nodes,
 					nodeGroupsState["example"],
 					2,
@@ -101,6 +102,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 			args{
 				scaleOpts{
 					nodes,
+					[]*v1.Node{},
 					[]*v1.Node{},
 					nodes,
 					nodeGroupsState["example"],
@@ -117,6 +119,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 				scaleOpts{
 					nodes[:2],
 					[]*v1.Node{},
+					[]*v1.Node{},
 					nodes[:2],
 					nodeGroupsState["example"],
 					4,
@@ -132,6 +135,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 				scaleOpts{
 					nodes[:3],
 					[]*v1.Node{},
+					[]*v1.Node{},
 					nodes[:3],
 					nodeGroupsState["default"],
 					4,
@@ -146,6 +150,7 @@ func TestControllerScaleDownTaint(t *testing.T) {
 			args{
 				scaleOpts{
 					nodes,
+					[]*v1.Node{},
 					[]*v1.Node{},
 					nodes,
 					nodeGroupsState["default"],
@@ -451,6 +456,7 @@ func TestController_TryRemoveTaintedNodes(t *testing.T) {
 			scaleOpts{
 				nodes,
 				taintedNodes,
+				[]*v1.Node{},
 				untaintedNodes,
 				nodeGroupsState[testNodeGroup.ID()],
 				0, // not used in TryRemoveTaintedNodes
@@ -464,6 +470,7 @@ func TestController_TryRemoveTaintedNodes(t *testing.T) {
 			scaleOpts{
 				nodes,
 				taintedNodes,
+				[]*v1.Node{},
 				untaintedNodes,
 				nodeGroupsState[testNodeGroup.ID()],
 				0, // not used in TryRemoveTaintedNodes
@@ -476,6 +483,7 @@ func TestController_TryRemoveTaintedNodes(t *testing.T) {
 			"test none tainted",
 			scaleOpts{
 				nodes,
+				[]*v1.Node{},
 				[]*v1.Node{},
 				nodes,
 				nodeGroupsState[testNodeGroup.ID()],

--- a/pkg/k8s/taint.go
+++ b/pkg/k8s/taint.go
@@ -28,7 +28,8 @@ var TaintEffectTypes = map[apiv1.TaintEffect]bool{
 
 const (
 	// ToBeRemovedByAutoscalerKey specifies the key the autoscaler uses to taint nodes as MARKED
-	ToBeRemovedByAutoscalerKey = "atlassian.com/escalator"
+	ToBeRemovedByAutoscalerKey      = "atlassian.com/escalator"
+	ToBeForceRemovedByAutoscalerKey = "atlassian.com/escalator-force"
 )
 
 // AddToBeRemovedTaint takes a k8s node and adds the ToBeRemovedByAutoscaler taint to the node
@@ -80,6 +81,17 @@ func AddToBeRemovedTaint(node *apiv1.Node, client kubernetes.Interface, taintEff
 func GetToBeRemovedTaint(node *apiv1.Node) (apiv1.Taint, bool) {
 	for _, taint := range node.Spec.Taints {
 		if taint.Key == ToBeRemovedByAutoscalerKey {
+			return taint, true
+		}
+	}
+	return apiv1.Taint{}, false
+}
+
+// GetToBeRemovedTaint returns whether the node is tainted with the ToBeForceRemoved taint
+// and the taint associated
+func GetToBeForceRemovedTaint(node *apiv1.Node) (apiv1.Taint, bool) {
+	for _, taint := range node.Spec.Taints {
+		if taint.Key == ToBeForceRemovedByAutoscalerKey {
 			return taint, true
 		}
 	}

--- a/pkg/k8s/taint.go
+++ b/pkg/k8s/taint.go
@@ -28,7 +28,9 @@ var TaintEffectTypes = map[apiv1.TaintEffect]bool{
 
 const (
 	// ToBeRemovedByAutoscalerKey specifies the key the autoscaler uses to taint nodes as MARKED
-	ToBeRemovedByAutoscalerKey      = "atlassian.com/escalator"
+	ToBeRemovedByAutoscalerKey = "atlassian.com/escalator"
+
+	// ToBeForceRemovedByAutoscalerKey specifies the key used to mark a node for force removal
 	ToBeForceRemovedByAutoscalerKey = "atlassian.com/escalator-force"
 )
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -36,6 +36,15 @@ var (
 		},
 		[]string{"node_group"},
 	)
+	// NodeGroupNodesForceTainted nodes considered by specific node groups that are force tainted
+	NodeGroupNodesForceTainted = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_force_tainted_nodes",
+			Namespace: NAMESPACE,
+			Help:      "nodes considered by specific node groups that are force tainted",
+		},
+		[]string{"node_group"},
+	)
 	// NodeGroupNodesCordoned nodes considered by specific node groups
 	NodeGroupNodesCordoned = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/pkg/test/builder.go
+++ b/pkg/test/builder.go
@@ -16,13 +16,14 @@ import (
 
 // NodeOpts minimal options for configuring a node object in testing
 type NodeOpts struct {
-	Name       string
-	CPU        int64
-	Mem        int64
-	LabelKey   string
-	LabelValue string
-	Creation   time.Time
-	Tainted    bool
+	Name         string
+	CPU          int64
+	Mem          int64
+	LabelKey     string
+	LabelValue   string
+	Creation     time.Time
+	Tainted      bool
+	ForceTainted bool
 }
 
 // BuildFakeClient creates a fake client
@@ -111,6 +112,12 @@ func BuildTestNode(opts NodeOpts) *apiv1.Node {
 		taints = append(taints, apiv1.Taint{
 			Key:    "atlassian.com/escalator",
 			Value:  fmt.Sprint(time.Now().Unix()),
+			Effect: apiv1.TaintEffectNoSchedule,
+		})
+	}
+	if opts.ForceTainted {
+		taints = append(taints, apiv1.Taint{
+			Key:    "atlassian.com/escalator-force",
 			Effect: apiv1.TaintEffectNoSchedule,
 		})
 	}


### PR DESCRIPTION
closes #245 

# Summary

This PR is a WIP, TODOs:

- [x] Unit Tests
- [x] Documentation

Opening in progress to ensure maintainers are happy with the direction and patterns implemented #201 

These changes implement a new taint: `atlassian.com/escalator-force`

Nodes marked with this taint will be removed as soon as all non daemonset pods are completed. This is checked during the  Escalator loop

In the current design, this taint is not expected to be added by Escalator to any nodes. The expected usage is for an external system or administrator to implement the taint, and have Escalator perform the safe scale down.

Thank you! 