### PR TITLE
fix: consider only load on available nodes for utilisation

### DIFF
--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -17,6 +17,7 @@ node_groups:
     max_nodes: 30
     dry_mode: false
     scale_on_starve: false
+    exclude_tainted_node_pods: false
     taint_upper_capacity_threshold_percent: 40
     taint_lower_capacity_threshold_percent: 10
     slow_node_removal_rate: 2
@@ -107,6 +108,16 @@ whenever there is a pod that cannot currently be scheduled due to no node having
 
 Warning: You have to be extra careful around pod request sizes not exceeding node capacity when this option is enabled,
 or you may find the escalator always creates the maximum number of nodes.
+
+### `exclude_tainted_node_pods`
+
+When enabled, Escalator will exclude pods running on unavailable nodes from demand in the utilisation calculation. Unavailable nodes are tainted, force tainted, and cordoned nodes.
+
+Unscheduled (pending) pods are still included so that scale-up decisions account for outstanding demand.
+
+By default, Escalator aggregates pod resource requests across **all** pods in the node group, but calculates node capacity from only **untainted** nodes. This mismatch can inflate the utilisation percentage as pods on tainted or draining nodes are counted as demand, while the nodes they occupy are excluded from capacity. 
+
+The default value is `false` (disabled), preserving backward-compatible behavior.
 
 ### `taint_upper_capacity_threshold_percent`
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -237,8 +237,16 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	// Filter into untainted and tainted nodes
 	untaintedNodes, taintedNodes, forceTaintedNodes, cordonedNodes := c.filterNodes(nodeGroup, allNodes)
 
+	// Filter to pods on untainted nodes
+	if nodeGroup.Opts.ExcludeTaintedNodePods {
+		untaintedPods := k8s.FilterPodsByNode(pods, untaintedNodes, true)
+		log.WithField("nodegroup", nodegroup).Infof("pods total: %v (%v excluded on unavailable nodes)", len(pods), len(pods)-len(untaintedPods))
+		pods = untaintedPods
+	} else {
+		log.WithField("nodegroup", nodegroup).Infof("pods total: %v", len(pods))
+	}
+
 	// Metrics and Logs
-	log.WithField("nodegroup", nodegroup).Infof("pods total: %v", len(pods))
 	log.WithField("nodegroup", nodegroup).Infof("nodes remaining total: %v", len(allNodes))
 	log.WithField("nodegroup", nodegroup).Infof("cordoned nodes remaining total: %v", len(cordonedNodes))
 	log.WithField("nodegroup", nodegroup).Infof("nodes remaining untainted: %v", len(untaintedNodes))

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -240,8 +240,12 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	// Filter to pods on untainted nodes
 	if nodeGroup.Opts.ExcludeTaintedNodePods {
 		untaintedPods := k8s.FilterPodsByNode(pods, untaintedNodes, true)
-		log.WithField("nodegroup", nodegroup).Infof("pods total: %v (%v excluded on unavailable nodes)", len(pods), len(pods)-len(untaintedPods))
+		numberOfPods := len(pods)
+		numberOfExcludedPods := numberOfPods - len(untaintedPods)
 		pods = untaintedPods
+
+		log.WithField("nodegroup", nodegroup).Infof("pods total: %v (%v excluded from unavailable nodes)", numberOfPods, numberOfExcludedPods)
+		metrics.NodeGroupExcludedPods.WithLabelValues(nodegroup).Set(float64(numberOfExcludedPods))
 	} else {
 		log.WithField("nodegroup", nodegroup).Infof("pods total: %v", len(pods))
 	}

--- a/pkg/controller/controller_scale_node_group_test.go
+++ b/pkg/controller/controller_scale_node_group_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"testing"
 	stdtime "time"
 
@@ -1152,7 +1153,7 @@ func TestScaleDesiredNodesExceedsMaxNodes(t *testing.T) {
 						Mem:     8000,
 						Tainted: true,
 					})
-					return append(untainted, tainted...)  
+					return append(untainted, tainted...)
 				}(),
 				buildTestPods(10, 500, 1000), // 20% CPU utilization, should scale down by FastNodeRemovalRate
 				NodeGroupOptions{
@@ -1185,7 +1186,7 @@ func TestScaleDesiredNodesExceedsMaxNodes(t *testing.T) {
 					})
 					return append(untainted, tainted...)
 				}(),
-				buildTestPods(20, 500, 1000),   // 62% CPU utilization, normally no scaling
+				buildTestPods(20, 500, 1000), // 62% CPU utilization, normally no scaling
 				NodeGroupOptions{
 					Name:                               "default",
 					CloudProviderGroupName:             "default",
@@ -1249,6 +1250,185 @@ func TestScaleDesiredNodesExceedsMaxNodes(t *testing.T) {
 			assert.Equal(t, tt.expectedNodeDelta, nodesDelta)
 		})
 	}
+}
+
+func TestScaleNodeGroupExcludeTaintedNodePods(t *testing.T) {
+	buildController := func(t *testing.T, nodes []*v1.Node, pods []*v1.Pod, excludeTaintedNodePods bool) (*Controller, map[string]*NodeGroupState) {
+		t.Helper()
+		nodeGroupOpts := NodeGroupOptions{
+			Name:                    "default",
+			CloudProviderGroupName:  "default",
+			MinNodes:                5,
+			MaxNodes:                100,
+			ScaleUpThresholdPercent: 70,
+			ExcludeTaintedNodePods:  excludeTaintedNodePods,
+		}
+		nodeGroups := []NodeGroupOptions{nodeGroupOpts}
+		client, opts, err := buildTestClient(nodes, pods, nodeGroups, ListerOptions{})
+		require.NoError(t, err)
+
+		testCloudProvider := test.NewCloudProvider(1)
+		testCloudProvider.RegisterNodeGroup(test.NewNodeGroup(
+			nodeGroupOpts.CloudProviderGroupName,
+			nodeGroupOpts.Name,
+			int64(nodeGroupOpts.MinNodes),
+			int64(nodeGroupOpts.MaxNodes),
+			int64(len(nodes)),
+		))
+		nodeGroupsState := BuildNodeGroupsState(nodeGroupsStateOpts{nodeGroups: nodeGroups, client: *client})
+
+		controller := &Controller{
+			Client:        client,
+			Opts:          opts,
+			nodeGroups:    nodeGroupsState,
+			cloudProvider: testCloudProvider,
+		}
+		return controller, nodeGroupsState
+	}
+
+	t.Run("flag disabled - tainted node pods inflate utilisation, triggers scale up", func(t *testing.T) {
+		untaintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000})
+		taintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000, Tainted: true})
+		nodes := append(untaintedNodes, taintedNodes...)
+
+		// 25 pods on untainted nodes (50% utilisation of untainted capacity)
+		var pods []*v1.Pod
+		for i, node := range untaintedNodes {
+			for j := 0; j < 5; j++ {
+				pods = append(pods, test.BuildTestPod(test.PodOpts{
+					CPU:      []int64{200},
+					Mem:      []int64{800},
+					NodeName: node.Name,
+					Running:  true,
+					Phase:    v1.PodRunning,
+					Name:     fmt.Sprintf("untainted-pod-%d-%d", i, j),
+				}))
+			}
+		}
+		// 25 pods on tainted nodes
+		for i, node := range taintedNodes {
+			for j := 0; j < 5; j++ {
+				pods = append(pods, test.BuildTestPod(test.PodOpts{
+					CPU:      []int64{200},
+					Mem:      []int64{800},
+					NodeName: node.Name,
+					Running:  true,
+					Phase:    v1.PodRunning,
+					Name:     fmt.Sprintf("tainted-pod-%d-%d", i, j),
+				}))
+			}
+		}
+		controller, nodeGroupsState := buildController(t, nodes, pods, false)
+
+		// All 50 pods counted: 10000 CPU / 10000 untainted capacity = 100% > 70% threshold
+		nodesDelta, err := controller.scaleNodeGroup("default", nodeGroupsState["default"])
+		require.NoError(t, err)
+		assert.True(t, nodesDelta > 0, "expected scale up due to inflated utilisation but got delta %v", nodesDelta)
+	})
+
+	t.Run("flag enabled - accurate utilisation, no scale up", func(t *testing.T) {
+		untaintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000})
+		taintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000, Tainted: true})
+		nodes := append(untaintedNodes, taintedNodes...)
+
+		// 25 pods on untainted nodes (50% utilisation of untainted capacity)
+		var pods []*v1.Pod
+		for i, node := range untaintedNodes {
+			for j := 0; j < 5; j++ {
+				pods = append(pods, test.BuildTestPod(test.PodOpts{
+					CPU:      []int64{200},
+					Mem:      []int64{800},
+					NodeName: node.Name,
+					Running:  true,
+					Phase:    v1.PodRunning,
+					Name:     fmt.Sprintf("untainted-pod-%d-%d", i, j),
+				}))
+			}
+		}
+		// 25 pods on tainted nodes
+		for i, node := range taintedNodes {
+			for j := 0; j < 5; j++ {
+				pods = append(pods, test.BuildTestPod(test.PodOpts{
+					CPU:      []int64{200},
+					Mem:      []int64{800},
+					NodeName: node.Name,
+					Running:  true,
+					Phase:    v1.PodRunning,
+					Name:     fmt.Sprintf("tainted-pod-%d-%d", i, j),
+				}))
+			}
+		}
+		controller, nodeGroupsState := buildController(t, nodes, pods, true)
+
+		// Only untainted pods counted: 5000 CPU / 10000 untainted capacity = 50% < 70% threshold
+		nodesDelta, err := controller.scaleNodeGroup("default", nodeGroupsState["default"])
+		require.NoError(t, err)
+		assert.Equal(t, 0, nodesDelta)
+	})
+
+	t.Run("flag enabled - still scales up when genuinely overloaded on untainted nodes", func(t *testing.T) {
+		untaintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000})
+		taintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000, Tainted: true})
+		nodes := append(untaintedNodes, taintedNodes...)
+
+		// 40 heavy pods only on untainted nodes: 8000 CPU / 10000 capacity = 80%
+		var pods []*v1.Pod
+		for i, node := range untaintedNodes {
+			for j := 0; j < 8; j++ {
+				pods = append(pods, test.BuildTestPod(test.PodOpts{
+					CPU:      []int64{200},
+					Mem:      []int64{800},
+					NodeName: node.Name,
+					Running:  true,
+					Phase:    v1.PodRunning,
+					Name:     fmt.Sprintf("heavy-pod-%d-%d", i, j),
+				}))
+			}
+		}
+
+		controller, nodeGroupsState := buildController(t, nodes, pods, true)
+
+		// 80% > 70% threshold, should scale up
+		nodesDelta, err := controller.scaleNodeGroup("default", nodeGroupsState["default"])
+		require.NoError(t, err)
+		assert.True(t, nodesDelta > 0, "expected scale up but got delta %v", nodesDelta)
+	})
+
+	t.Run("flag enabled - pending unscheduled pods still count toward demand", func(t *testing.T) {
+		untaintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000})
+		taintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000, Tainted: true})
+		nodes := append(untaintedNodes, taintedNodes...)
+
+		// 25 moderate pods on untainted nodes (50% utilisation)
+		var pods []*v1.Pod
+		for i, node := range untaintedNodes {
+			for j := 0; j < 5; j++ {
+				pods = append(pods, test.BuildTestPod(test.PodOpts{
+					CPU:      []int64{200},
+					Mem:      []int64{800},
+					NodeName: node.Name,
+					Running:  true,
+					Phase:    v1.PodRunning,
+					Name:     fmt.Sprintf("moderate-pod-%d-%d", i, j),
+				}))
+			}
+		}
+		// Add a large pending unscheduled pod that pushes demand over the threshold
+		pods = append(pods, test.BuildTestPod(test.PodOpts{
+			CPU:     []int64{5000},
+			Mem:     []int64{20000},
+			Phase:   v1.PodPending,
+			Running: false,
+			Name:    "large-pending-pod",
+		}))
+
+		controller, nodeGroupsState := buildController(t, nodes, pods, true)
+
+		// 25 untainted pods (5000 CPU) + 1 pending (5000 CPU) = 10000 / 10000 = 100% > 70%
+		nodesDelta, err := controller.scaleNodeGroup("default", nodeGroupsState["default"])
+		require.NoError(t, err)
+		assert.True(t, nodesDelta > 0, "expected scale up due to pending pod but got delta %v", nodesDelta)
+	})
 }
 
 func TestScaleNodeGroupNodeMaxAge(t *testing.T) {
@@ -1406,7 +1586,7 @@ func TestScaleNodeGroupNodeMaxAge(t *testing.T) {
 			"max_node_age enabled, scaled down to zero",
 			args{
 				nodes: []*v1.Node{},
-				pods: nil,
+				pods:  nil,
 				nodeGroupOptions: NodeGroupOptions{
 					Name:                    "default",
 					CloudProviderGroupName:  "default",

--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -30,6 +30,8 @@ type NodeGroupOptions struct {
 
 	ScaleOnStarve bool `json:"scale_on_starve,omitempty" yaml:"scale_on_starve,omitempty"`
 
+	ExcludeTaintedNodePods bool `json:"exclude_tainted_node_pods,omitempty" yaml:"exclude_tainted_node_pods,omitempty"`
+
 	TaintUpperCapacityThresholdPercent int `json:"taint_upper_capacity_threshold_percent,omitempty" yaml:"taint_upper_capacity_threshold_percent,omitempty"`
 	TaintLowerCapacityThresholdPercent int `json:"taint_lower_capacity_threshold_percent,omitempty" yaml:"taint_lower_capacity_threshold_percent,omitempty"`
 

--- a/pkg/k8s/util.go
+++ b/pkg/k8s/util.go
@@ -71,6 +71,32 @@ func CalculatePodsRequestedUsage(pods []*v1.Pod) (PodRequestedUsage, error) {
 	return ret, nil
 }
 
+// FilterPodsByNode returns the list of pods that are scheduled to a node contained
+// in the provided list, optionally included unscheduled pods
+func FilterPodsByNode(pods []*v1.Pod, nodes []*v1.Node, includeUnscheduled bool) []*v1.Pod {
+	nodesMap := make(map[string]struct{})
+	for _, n := range nodes {
+		nodesMap[n.Name] = struct{}{} // marker
+	}
+
+	filtered := make([]*v1.Pod, 0, len(pods))
+	for _, pod := range pods {
+		name := pod.Spec.NodeName
+
+		// handle unscheduled pods
+		if len(name) == 0 && includeUnscheduled {
+			filtered = append(filtered, pod)
+			continue
+		}
+
+		_, found := nodesMap[name]
+		if found {
+			filtered = append(filtered, pod)
+		}
+	}
+	return filtered
+}
+
 // CalculateNodesCapacity calculates the total Allocatable node capacity for all nodes,
 // as well as the 2 nodes with the largest available CPU and memory
 func CalculateNodesCapacity(nodes []*v1.Node, pods []*v1.Pod) (NodeAvailableCapacity, error) {

--- a/pkg/k8s/util_test.go
+++ b/pkg/k8s/util_test.go
@@ -218,6 +218,109 @@ func TestCalculatePodsRequestTotal(t *testing.T) {
 	}
 }
 
+func TestFilterPodsByNode(t *testing.T) {
+	nodeA := test.BuildTestNode(test.NodeOpts{Name: "node-a", CPU: 1000, Mem: 1000})
+	nodeB := test.BuildTestNode(test.NodeOpts{Name: "node-b", CPU: 1000, Mem: 1000})
+	nodeC := test.BuildTestNode(test.NodeOpts{Name: "node-c", CPU: 1000, Mem: 1000})
+
+	podOnA := test.BuildTestPod(test.PodOpts{Name: "pod-a", CPU: []int64{100}, Mem: []int64{100}, NodeName: "node-a"})
+	podOnA2 := test.BuildTestPod(test.PodOpts{Name: "pod-a2", CPU: []int64{100}, Mem: []int64{100}, NodeName: "node-a"})
+	podOnB := test.BuildTestPod(test.PodOpts{Name: "pod-b", CPU: []int64{100}, Mem: []int64{100}, NodeName: "node-b"})
+	podOnC := test.BuildTestPod(test.PodOpts{Name: "pod-c", CPU: []int64{100}, Mem: []int64{100}, NodeName: "node-c"})
+	unscheduledPod1 := test.BuildTestPod(test.PodOpts{Name: "unscheduled-1", CPU: []int64{100}, Mem: []int64{100}})
+	unscheduledPod2 := test.BuildTestPod(test.PodOpts{Name: "unscheduled-2", CPU: []int64{100}, Mem: []int64{100}})
+
+	type args struct {
+		pods               []*v1.Pod
+		nodes              []*v1.Node
+		includeUnscheduled bool
+	}
+	tests := []struct {
+		name     string
+		args     args
+		expected []*v1.Pod
+	}{
+		{
+			"empty pods and empty nodes",
+			args{
+				[]*v1.Pod{},
+				[]*v1.Node{},
+				true,
+			},
+			[]*v1.Pod{},
+		},
+		{
+			"pods matching nodes are included",
+			args{
+				[]*v1.Pod{podOnA, podOnB, podOnC},
+				[]*v1.Node{nodeA, nodeB, nodeC},
+				true,
+			},
+			[]*v1.Pod{podOnA, podOnB, podOnC},
+		},
+		{
+			"pods not matching nodes are excluded",
+			args{
+				[]*v1.Pod{podOnA, podOnC},
+				[]*v1.Node{nodeA, nodeB},
+				true,
+			},
+			[]*v1.Pod{podOnA},
+		},
+		{
+			"multiple pods on nodes are included",
+			args{
+				[]*v1.Pod{podOnA, podOnA2, podOnB},
+				[]*v1.Node{nodeA},
+				true,
+			},
+			[]*v1.Pod{podOnA, podOnA2},
+		},
+		{
+			"unscheduled pods included when flag is true",
+			args{
+				[]*v1.Pod{podOnA, podOnB, unscheduledPod1},
+				[]*v1.Node{nodeA},
+				true,
+			},
+			[]*v1.Pod{podOnA, unscheduledPod1},
+		},
+		{
+			"unscheduled pods excluded when flag is false",
+			args{
+				[]*v1.Pod{podOnA, podOnB, unscheduledPod1},
+				[]*v1.Node{nodeA},
+				false,
+			},
+			[]*v1.Pod{podOnA},
+		},
+		{
+			"all unscheduled pods included when flag is true",
+			args{
+				[]*v1.Pod{unscheduledPod1, unscheduledPod2},
+				[]*v1.Node{},
+				true,
+			},
+			[]*v1.Pod{unscheduledPod1, unscheduledPod2},
+		},
+		{
+			"all unscheduled pods excluded when flag is false",
+			args{
+				[]*v1.Pod{unscheduledPod1, unscheduledPod2},
+				[]*v1.Node{},
+				false,
+			},
+			[]*v1.Pod{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := k8s.FilterPodsByNode(tt.args.pods, tt.args.nodes, tt.args.includeUnscheduled)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
 func TestCalculateNodesCapacity(t *testing.T) {
 	n1 := test.BuildTestNode(test.NodeOpts{
 		CPU: 1000,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -72,6 +72,15 @@ var (
 		},
 		[]string{"node_group"},
 	)
+	// NodeGroupExcludedPods pods excluded from consideration by specific node groups
+	NodeGroupExcludedPods = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_excluded_pods",
+			Namespace: NAMESPACE,
+			Help:      "pods excluded from consideration by specific node groups (running on tainted or cordoned nodes)",
+		},
+		[]string{"node_group"},
+	)
 	// NodeGroupUnhealthy nodes considered by specific node groups that are unhealthy
 	NodeGroupUnhealthy = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is an [alternative implementation](https://github.com/atlassian/escalator/pull/285/changes#r2992284298) to fix the issue described in https://github.com/atlassian/escalator/pull/285 

## What 🎯 

Introduces a node group option `exclude_tainted_node_pods` that configures Escalator to ignore resource demand of pods on nodes that are unavailable for scheduling -- nodes that are tainted, force tainted, or cordoned.

Unscheduled pods continue to count towards demand calculation.

## Why 💭 

Escalator currently computes utilisation as follows:

```
 resources used on nodes (untainted, tainted, cordoned)
---------------------------------------------------------
         resources available on untainted nodes
```

This limiting to `untainted` on the denominator causes utilisation to fluctuate as Escalator taints and untaints nodes.

As described in https://github.com/atlassian/escalator/pull/285

> We observed this in production on a cluster running  ~92 bare-metal nodes (m6id.metal, 128 vCPU each). During a demand transition:
>
>  - Utilisation dropped to 47.8%, triggering tainting at 3 nodes per 30-second cycle
>  - Over 11 minutes, 24 nodes were tainted
>  - The shrinking denominator caused a 26-point utilisation spike in a single scan cycle (48% to 74.5%) with no change in actual demand
>  - Escalator reversed and untainted 22 of the 24 nodes, but 12 EC2 instances had already been terminated and replaced

Whereas https://github.com/atlassian/escalator/pull/285 fixed by expanding the denominator, this PR fixes by filtering the numerator.

The rationale being that we want to measure utilisation from the perspective of the scheduler. The scheduler's view of capacity is of "in service" nodes where it can place pods, so tainted and cordoned nodes are not relevant and neither is the level of demand on those nodes currently.

```
      resources used on untainted nodes
---------------------------------------------
   resources available on untainted nodes
```

If a tainted or cordoned node is highly utilised or underutilised, that fact will enter the equation when and if Escalator returns the node to service.

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
Upgrade to Rovo Dev Standard to continue using code review.
<!-- /Rovo Dev code review status -->

