### PR TITLE
fix: build NodeInfoMap before ExcludeTaintedNodePods filter

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -237,11 +237,6 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	// Filter into untainted and tainted nodes
 	untaintedNodes, taintedNodes, forceTaintedNodes, cordonedNodes := c.filterNodes(nodeGroup, allNodes)
 
-	// Build NodeInfoMap BEFORE filtering tainted node pods so it always reflects
-	// the true pod state on every node. TryRemoveTaintedNodes uses NodeInfoMap to
-	// determine whether a tainted node is empty; if we built it from an already-
-	// filtered pod list, NodeEmpty() would incorrectly return true for tainted nodes
-	// that still have running pods, causing premature soft-path deletion.
 	nodeGroup.NodeInfoMap = k8s.CreateNodeNameToInfoMap(pods, allNodes)
 
 	// Filter to pods on untainted nodes (for capacity calculations only)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -237,7 +237,14 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 	// Filter into untainted and tainted nodes
 	untaintedNodes, taintedNodes, forceTaintedNodes, cordonedNodes := c.filterNodes(nodeGroup, allNodes)
 
-	// Filter to pods on untainted nodes
+	// Build NodeInfoMap BEFORE filtering tainted node pods so it always reflects
+	// the true pod state on every node. TryRemoveTaintedNodes uses NodeInfoMap to
+	// determine whether a tainted node is empty; if we built it from an already-
+	// filtered pod list, NodeEmpty() would incorrectly return true for tainted nodes
+	// that still have running pods, causing premature soft-path deletion.
+	nodeGroup.NodeInfoMap = k8s.CreateNodeNameToInfoMap(pods, allNodes)
+
+	// Filter to pods on untainted nodes (for capacity calculations only)
 	if nodeGroup.Opts.ExcludeTaintedNodePods {
 		untaintedPods := k8s.FilterPodsByNode(pods, untaintedNodes, true)
 		numberOfPods := len(pods)
@@ -281,10 +288,6 @@ func (c *Controller) scaleNodeGroup(nodegroup string, nodeGroup *NodeGroupState)
 		)
 		return 0, err
 	}
-
-	// update the map of node to nodeinfo
-	// for working out which pods are on which nodes
-	nodeGroup.NodeInfoMap = k8s.CreateNodeNameToInfoMap(pods, allNodes)
 
 	// Calc capacity for untainted nodes
 	podRequests, err := k8s.CalculatePodsRequestedUsage(pods)

--- a/pkg/controller/scale_down_test.go
+++ b/pkg/controller/scale_down_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -722,4 +723,122 @@ func TestController_TryRemoveTaintedNodes(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestTryRemoveTaintedNodes_ExcludeTaintedNodePods verifies that when
+// ExcludeTaintedNodePods is enabled, a tainted node that still has running
+// (non-daemonset) pods is NOT deleted via the soft path even after the
+// soft_delete_grace_period has elapsed.
+//
+// This is the regression test for the bug where NodeInfoMap was built from the
+// already-filtered pod list, making NodeEmpty() always return true for tainted
+// nodes and causing premature soft-path deletion of nodes with running pods.
+func TestTryRemoveTaintedNodes_ExcludeTaintedNodePods(t *testing.T) {
+	minNodes := 5
+	maxNodes := 20
+	softDeleteGracePeriod := "1m"
+	hardDeleteGracePeriod := "10m"
+
+	nodeGroupOpts := NodeGroupOptions{
+		Name:                   "default",
+		CloudProviderGroupName: "default",
+		MinNodes:               minNodes,
+		MaxNodes:               maxNodes,
+		// Soft period has elapsed so the node is eligible for soft deletion
+		SoftDeleteGracePeriod:  softDeleteGracePeriod,
+		HardDeleteGracePeriod:  hardDeleteGracePeriod,
+		ExcludeTaintedNodePods: true,
+	}
+	nodeGroups := []NodeGroupOptions{nodeGroupOpts}
+
+	// Build one tainted node whose escalator taint timestamp is 5 minutes in
+	// the past — beyond SoftDeleteGracePeriod (1m) but within HardDeleteGracePeriod (10m).
+	taintedNode := test.BuildTestNode(test.NodeOpts{
+		Name:    "tainted-node-with-pods",
+		CPU:     2000,
+		Mem:     8000,
+		Tainted: false, // we set the taint manually below to control the timestamp
+	})
+	taintTimestamp := time.Now().Add(-5 * time.Minute)
+	taintedNode.Spec.Taints = []v1.Taint{
+		{
+			Key:    k8s.ToBeRemovedByAutoscalerKey,
+			Value:  strconv.FormatInt(taintTimestamp.Unix(), 10),
+			Effect: v1.TaintEffectNoSchedule,
+		},
+	}
+
+	// Build some untainted nodes to satisfy MinNodes and capacity requirements.
+	untaintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000})
+	allNodes := append(untaintedNodes, taintedNode)
+
+	// Place a regular (non-daemonset) running pod on the tainted node.
+	// This pod should prevent soft-path deletion.
+	podOnTaintedNode := test.BuildTestPod(test.PodOpts{
+		Name:     "job-pod-on-tainted-node",
+		CPU:      []int64{500},
+		Mem:      []int64{1000},
+		NodeName: taintedNode.Name,
+		Running:  true,
+		Phase:    v1.PodRunning,
+	})
+
+	// Also put some pods on untainted nodes (for capacity calculations).
+	var allPods []*v1.Pod
+	allPods = append(allPods, podOnTaintedNode)
+	for i, node := range untaintedNodes {
+		allPods = append(allPods, test.BuildTestPod(test.PodOpts{
+			Name:     fmt.Sprintf("untainted-pod-%d", i),
+			CPU:      []int64{200},
+			Mem:      []int64{800},
+			NodeName: node.Name,
+			Running:  true,
+			Phase:    v1.PodRunning,
+		}))
+	}
+
+	client, opts, err := buildTestClient(allNodes, allPods, nodeGroups, ListerOptions{})
+	require.NoError(t, err)
+
+	testCloudProvider := test.NewCloudProvider(1)
+	testCloudProvider.RegisterNodeGroup(test.NewNodeGroup(
+		nodeGroupOpts.CloudProviderGroupName,
+		nodeGroupOpts.Name,
+		int64(minNodes),
+		int64(maxNodes),
+		int64(len(allNodes)),
+	))
+
+	nodeGroupsState := BuildNodeGroupsState(nodeGroupsStateOpts{
+		nodeGroups: nodeGroups,
+		client:     *client,
+	})
+
+	// Build NodeInfoMap from ALL pods (including the pod on the tainted node).
+	// This is what the fixed code does: NodeInfoMap is constructed before the
+	// ExcludeTaintedNodePods filter so it accurately reflects tainted-node state.
+	nodeGroupsState[nodeGroupOpts.Name].NodeInfoMap = k8s.CreateNodeNameToInfoMap(allPods, allNodes)
+
+	c := &Controller{
+		Client:        client,
+		Opts:          opts,
+		stopChan:      nil,
+		nodeGroups:    nodeGroupsState,
+		cloudProvider: testCloudProvider,
+	}
+
+	scaleOptions := scaleOpts{
+		nodes:             allNodes,
+		taintedNodes:      []*v1.Node{taintedNode},
+		forceTaintedNodes: []*v1.Node{},
+		untaintedNodes:    untaintedNodes,
+		nodeGroup:         nodeGroupsState[nodeGroupOpts.Name],
+	}
+
+	// The tainted node has a running pod, so it must NOT be deleted via the
+	// soft path (soft grace period elapsed but hard grace period has not).
+	removed, err := c.TryRemoveTaintedNodes(scaleOptions, true)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, removed,
+		"tainted node with a running pod must not be deleted via the soft path when ExcludeTaintedNodePods is enabled")
 }

--- a/pkg/controller/scale_down_test.go
+++ b/pkg/controller/scale_down_test.go
@@ -725,29 +725,33 @@ func TestController_TryRemoveTaintedNodes(t *testing.T) {
 	}
 }
 
-// TestTryRemoveTaintedNodes_ExcludeTaintedNodePods verifies that when
-// ExcludeTaintedNodePods is enabled, a tainted node that still has running
+// Test verifies that when ExcludeTaintedNodePods is enabled, a tainted node that still has running
 // (non-daemonset) pods is NOT deleted via the soft path even after the
 // soft_delete_grace_period has elapsed.
-//
-// This is the regression test for the bug where NodeInfoMap was built from the
-// already-filtered pod list, making NodeEmpty() always return true for tainted
-// nodes and causing premature soft-path deletion of nodes with running pods.
-func TestTryRemoveTaintedNodes_ExcludeTaintedNodePods(t *testing.T) {
-	minNodes := 5
+func TestTryRemoveTaintedNodes_WithExcludeTaintedNodePodsAndTaintedNodeHasPods(t *testing.T) {
+	minNodes := 0
 	maxNodes := 20
 	softDeleteGracePeriod := "1m"
 	hardDeleteGracePeriod := "10m"
 
+	// Thresholds are set so that ~50% utilisation (from untainted pods only)
+	// falls between TaintUpperCapacityThresholdPercent and ScaleUpThresholdPercent,
+	// leaving nodesDelta=0 and routing execution to TryRemoveTaintedNodes.
+	scaleUpThresholdPercent := 70
+	taintUpperCapacityThresholdPercent := 40
+	taintLowerCapacityThresholdPercent := 20
+
 	nodeGroupOpts := NodeGroupOptions{
-		Name:                   "default",
-		CloudProviderGroupName: "default",
-		MinNodes:               minNodes,
-		MaxNodes:               maxNodes,
-		// Soft period has elapsed so the node is eligible for soft deletion
-		SoftDeleteGracePeriod:  softDeleteGracePeriod,
-		HardDeleteGracePeriod:  hardDeleteGracePeriod,
-		ExcludeTaintedNodePods: true,
+		Name:                               "default",
+		CloudProviderGroupName:             "default",
+		MinNodes:                           minNodes,
+		MaxNodes:                           maxNodes,
+		ScaleUpThresholdPercent:            scaleUpThresholdPercent,
+		TaintUpperCapacityThresholdPercent: taintUpperCapacityThresholdPercent,
+		TaintLowerCapacityThresholdPercent: taintLowerCapacityThresholdPercent,
+		SoftDeleteGracePeriod:              softDeleteGracePeriod,
+		HardDeleteGracePeriod:              hardDeleteGracePeriod,
+		ExcludeTaintedNodePods:             true,
 	}
 	nodeGroups := []NodeGroupOptions{nodeGroupOpts}
 
@@ -768,8 +772,8 @@ func TestTryRemoveTaintedNodes_ExcludeTaintedNodePods(t *testing.T) {
 		},
 	}
 
-	// Build some untainted nodes to satisfy MinNodes and capacity requirements.
-	untaintedNodes := test.BuildTestNodes(5, test.NodeOpts{CPU: 2000, Mem: 8000})
+	// Build untainted nodes for capacity calculations.
+	untaintedNodes := test.BuildTestNodes(2, test.NodeOpts{CPU: 2000, Mem: 8000})
 	allNodes := append(untaintedNodes, taintedNode)
 
 	// Place a regular (non-daemonset) running pod on the tainted node.
@@ -783,14 +787,17 @@ func TestTryRemoveTaintedNodes_ExcludeTaintedNodePods(t *testing.T) {
 		Phase:    v1.PodRunning,
 	})
 
-	// Also put some pods on untainted nodes (for capacity calculations).
+	// Put pods on untainted nodes at ~50% utilisation so the controller neither
+	// scales up (< 70%) nor scales down (> 40%), landing on nodesDelta=0 and
+	// exercising TryRemoveTaintedNodes via scaleNodeGroup.
+	// Each untainted node: 2000m CPU. 2 nodes × 1000m = 2000m / 4000m total = 50%.
 	var allPods []*v1.Pod
 	allPods = append(allPods, podOnTaintedNode)
 	for i, node := range untaintedNodes {
 		allPods = append(allPods, test.BuildTestPod(test.PodOpts{
 			Name:     fmt.Sprintf("untainted-pod-%d", i),
-			CPU:      []int64{200},
-			Mem:      []int64{800},
+			CPU:      []int64{1000},
+			Mem:      []int64{4000},
 			NodeName: node.Name,
 			Running:  true,
 			Phase:    v1.PodRunning,
@@ -801,23 +808,20 @@ func TestTryRemoveTaintedNodes_ExcludeTaintedNodePods(t *testing.T) {
 	require.NoError(t, err)
 
 	testCloudProvider := test.NewCloudProvider(1)
-	testCloudProvider.RegisterNodeGroup(test.NewNodeGroup(
+	initialNodeCount := int64(len(allNodes))
+	testNodeGroup := test.NewNodeGroup(
 		nodeGroupOpts.CloudProviderGroupName,
 		nodeGroupOpts.Name,
 		int64(minNodes),
 		int64(maxNodes),
-		int64(len(allNodes)),
-	))
+		initialNodeCount,
+	)
+	testCloudProvider.RegisterNodeGroup(testNodeGroup)
 
 	nodeGroupsState := BuildNodeGroupsState(nodeGroupsStateOpts{
 		nodeGroups: nodeGroups,
 		client:     *client,
 	})
-
-	// Build NodeInfoMap from ALL pods (including the pod on the tainted node).
-	// This is what the fixed code does: NodeInfoMap is constructed before the
-	// ExcludeTaintedNodePods filter so it accurately reflects tainted-node state.
-	nodeGroupsState[nodeGroupOpts.Name].NodeInfoMap = k8s.CreateNodeNameToInfoMap(allPods, allNodes)
 
 	c := &Controller{
 		Client:        client,
@@ -827,18 +831,117 @@ func TestTryRemoveTaintedNodes_ExcludeTaintedNodePods(t *testing.T) {
 		cloudProvider: testCloudProvider,
 	}
 
-	scaleOptions := scaleOpts{
-		nodes:             allNodes,
-		taintedNodes:      []*v1.Node{taintedNode},
-		forceTaintedNodes: []*v1.Node{},
-		untaintedNodes:    untaintedNodes,
-		nodeGroup:         nodeGroupsState[nodeGroupOpts.Name],
+	// Drive the full scaleNodeGroup path so the NodeInfoMap ordering fix is
+	// exercised end-to-end: scaleNodeGroup must build NodeInfoMap before the
+	// ExcludeTaintedNodePods filter runs, otherwise NodeEmpty() incorrectly
+	// returns true for tainted nodes that still have running pods.
+	nodesDelta, err := c.scaleNodeGroup(nodeGroupOpts.Name, nodeGroupsState[nodeGroupOpts.Name])
+	assert.NoError(t, err)
+	assert.Equal(t, 0, nodesDelta,
+		"tainted node with a running pod must not be deleted via the soft path when ExcludeTaintedNodePods is enabled")
+	assert.Equal(t, initialNodeCount, testNodeGroup.TargetSize(),
+		"cloud provider DeleteNodes should not have been called")
+}
+
+func TestTryRemoveTaintedNodes_WithExcludeTaintedNodePodsAndTaintedNodeHasNoPods(t *testing.T) {
+	minNodes := 0
+	maxNodes := 20
+	softDeleteGracePeriod := "1m"
+	hardDeleteGracePeriod := "10m"
+
+	// Thresholds are set so that ~50% utilisation (from untainted pods only)
+	// falls between TaintUpperCapacityThresholdPercent and ScaleUpThresholdPercent,
+	// leaving nodesDelta=0 and routing execution to TryRemoveTaintedNodes.
+	scaleUpThresholdPercent := 70
+	taintUpperCapacityThresholdPercent := 40
+	taintLowerCapacityThresholdPercent := 20
+
+	nodeGroupOpts := NodeGroupOptions{
+		Name:                               "default",
+		CloudProviderGroupName:             "default",
+		MinNodes:                           minNodes,
+		MaxNodes:                           maxNodes,
+		ScaleUpThresholdPercent:            scaleUpThresholdPercent,
+		TaintUpperCapacityThresholdPercent: taintUpperCapacityThresholdPercent,
+		TaintLowerCapacityThresholdPercent: taintLowerCapacityThresholdPercent,
+		SoftDeleteGracePeriod:              softDeleteGracePeriod,
+		HardDeleteGracePeriod:              hardDeleteGracePeriod,
+		ExcludeTaintedNodePods:             true,
+	}
+	nodeGroups := []NodeGroupOptions{nodeGroupOpts}
+
+	// Build one tainted node whose escalator taint timestamp is 5 minutes in
+	// the past — beyond SoftDeleteGracePeriod (1m) but within HardDeleteGracePeriod (10m).
+	// This node has NO pods, so it should be deleted via the soft path.
+	taintedNode := test.BuildTestNode(test.NodeOpts{
+		Name:    "tainted-node-no-pods",
+		CPU:     2000,
+		Mem:     8000,
+		Tainted: false, // we set the taint manually below to control the timestamp
+	})
+	taintTimestamp := time.Now().Add(-5 * time.Minute)
+	taintedNode.Spec.Taints = []v1.Taint{
+		{
+			Key:    k8s.ToBeRemovedByAutoscalerKey,
+			Value:  strconv.FormatInt(taintTimestamp.Unix(), 10),
+			Effect: v1.TaintEffectNoSchedule,
+		},
 	}
 
-	// The tainted node has a running pod, so it must NOT be deleted via the
-	// soft path (soft grace period elapsed but hard grace period has not).
-	removed, err := c.TryRemoveTaintedNodes(scaleOptions, true)
+	// Build untainted nodes for capacity calculations.
+	untaintedNodes := test.BuildTestNodes(2, test.NodeOpts{CPU: 2000, Mem: 8000})
+	allNodes := append(untaintedNodes, taintedNode)
+
+	// Put pods on untainted nodes at ~50% utilisation so the controller neither
+	// scales up (< 70%) nor scales down (> 40%), landing on nodesDelta=0 and
+	// exercising TryRemoveTaintedNodes via scaleNodeGroup.
+	// Each untainted node: 2000m CPU. 2 nodes × 1000m = 2000m / 4000m total = 50%.
+	// No pods on the tainted node.
+	var allPods []*v1.Pod
+	for i, node := range untaintedNodes {
+		allPods = append(allPods, test.BuildTestPod(test.PodOpts{
+			Name:     fmt.Sprintf("untainted-pod-%d", i),
+			CPU:      []int64{1000},
+			Mem:      []int64{4000},
+			NodeName: node.Name,
+			Running:  true,
+			Phase:    v1.PodRunning,
+		}))
+	}
+
+	client, opts, err := buildTestClient(allNodes, allPods, nodeGroups, ListerOptions{})
+	require.NoError(t, err)
+
+	testCloudProvider := test.NewCloudProvider(1)
+	initialNodeCount := int64(len(allNodes))
+	testNodeGroup := test.NewNodeGroup(
+		nodeGroupOpts.CloudProviderGroupName,
+		nodeGroupOpts.Name,
+		int64(minNodes),
+		int64(maxNodes),
+		initialNodeCount,
+	)
+	testCloudProvider.RegisterNodeGroup(testNodeGroup)
+
+	nodeGroupsState := BuildNodeGroupsState(nodeGroupsStateOpts{
+		nodeGroups: nodeGroups,
+		client:     *client,
+	})
+
+	c := &Controller{
+		Client:        client,
+		Opts:          opts,
+		stopChan:      nil,
+		nodeGroups:    nodeGroupsState,
+		cloudProvider: testCloudProvider,
+	}
+
+	// Drive the full scaleNodeGroup path. The tainted node has no pods,
+	// so it should be deleted via the soft path.
+	nodesDelta, err := c.scaleNodeGroup(nodeGroupOpts.Name, nodeGroupsState[nodeGroupOpts.Name])
 	assert.NoError(t, err)
-	assert.Equal(t, 0, removed,
-		"tainted node with a running pod must not be deleted via the soft path when ExcludeTaintedNodePods is enabled")
+	assert.Equal(t, 0, nodesDelta,
+		"nodesDelta should be 0 as utilisation is within thresholds")
+	assert.Equal(t, initialNodeCount-1, testNodeGroup.TargetSize(),
+		"cloud provider DeleteNodes should have been called for the empty tainted node")
 }


### PR DESCRIPTION
When ExcludeTaintedNodePods is enabled, NodeInfoMap was previously built from the already-filtered pod list, causing NodeEmpty() to always return true for tainted nodes. This resulted in premature soft-path deletion of nodes that still had running pods.

Fix: move CreateNodeNameToInfoMap() to before the ExcludeTaintedNodePods filter so it always reflects the true pod state. The filtered pod list is used only for capacity calculations (CPU/memory utilisation).

Also adds a regression test verifying that a tainted node with a running non-daemonset pod is not deleted via the soft path.

Address comments in #289 because I don't have permission to update that fork.

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev couldn't review this pull request</strong>
The pull request author does not have access to Rovo Dev.
<!-- /Rovo Dev code review status -->

