### PR TITLE
Upgrade alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY cmd cmd
 COPY pkg pkg
 RUN make build ENVVAR=$ENVVAR
 
-FROM alpine:20251224
+FROM alpine:3.24.1
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /go/src/github.com/atlassian/escalator/escalator ./main
 CMD [ "./main" ]


### PR DESCRIPTION
Bump Alpine base: `alpine:20251224` -> `alpine:3.24.1`

- musl: 1.2.5-r21 -> 1.2.6-r2
- zlib: 1.3.1-r2 -> 1.3.2-r0
- openssl: 3.5.5-r0 -> 3.5.7-r0