### PR TITLE
Add scale-up circuit breaker for unfulfilled ASG scale-ups

### DIFF
--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -26,7 +26,6 @@ node_groups:
     scale_up_cool_down_period: 2m
     scale_up_cool_down_timeout: 10m
     scale_up_failure_threshold: 5
-    scale_up_failure_cooldown: 30m
     soft_delete_grace_period: 1m
     hard_delete_grace_period: 10m
     taint_effect: NoExecute
@@ -179,9 +178,9 @@ the node failed to register with Kubernetes in time.
 Having the scale up activity timeout isn't necessarily a bad thing, it just acts as a fail safe in case scaling 
 activities take too long so that the scale lock isn't permanently enabled.
 
-### `scale_up_failure_threshold` and `scale_up_failure_cooldown`
+### `scale_up_failure_threshold`
 
-These options enable a scale-up circuit breaker that stops Escalator from repeatedly raising the ASG desired count
+This option enables a scale-up circuit breaker that stops Escalator from repeatedly raising the ASG desired count
 when the cloud provider cannot actually deliver new nodes (for example, when an instance type is temporarily out of
 capacity in an availability zone). Without it, Escalator keeps increasing the desired count every scan interval while
 pods stay pending, driving the desired count up to `max_nodes` even though no instances are launching.
@@ -192,17 +191,17 @@ number of consecutive failed scale-ups that trips the breaker. Once tripped, Esc
 count for that node group. Untainting of existing tainted nodes is unaffected, so already-running capacity can still
 be reused.
 
-Because fulfilment is judged once per scale-up (which is itself paced by `scale_up_cool_down_period`), set the cooldown
-long enough for the cloud provider to launch and attach instances. The same guidance already applies to a healthy
-scale-up. If the cooldown is shorter than typical instance launch latency, a healthy-but-slow node group could be
-mistaken for a stuck one.
+While the breaker is open there is no cooldown or waiting period. Escalator keeps looping and evaluating as normal, but
+holds the desired count steady at the target it last requested. When the running count catches up to that frozen target
+— that is, the cloud provider has finally delivered the capacity — the breaker closes and normal scaling resumes on the
+next scan. This means recovery is picked up as soon as capacity is available, without introducing scaling latency.
 
-`scale_up_failure_cooldown` is how long the breaker stays open before allowing a single half-open probe scale-up. If
-that probe also fails to reach its requested target, the breaker re-opens immediately; if running capacity has
-recovered, normal scaling resumes.
+Because fulfilment is judged once per scale-up (which is itself paced by `scale_up_cool_down_period`), set
+`scale_up_cool_down_period` long enough for the cloud provider to launch and attach instances. The same guidance already
+applies to a healthy scale-up. If it is shorter than typical instance launch latency, a healthy-but-slow node group
+could be mistaken for a stuck one.
 
 The feature is opt-in and disabled by default. Leave `scale_up_failure_threshold` unset (or `0`) to disable it.
-`scale_up_failure_cooldown` must be a positive Go duration when `scale_up_failure_threshold` is greater than `0`.
 
 Two metrics are exported while this is enabled: `escalator_node_group_scale_up_circuit_breaker_open` (1 when open, 0
 when closed) and `escalator_node_group_scale_up_failed_scale_events` (count of failed scale-up requests).

--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -25,6 +25,8 @@ node_groups:
     scale_up_threshold_percent: 70
     scale_up_cool_down_period: 2m
     scale_up_cool_down_timeout: 10m
+    scale_up_failure_threshold: 5
+    scale_up_failure_cooldown: 30m
     soft_delete_grace_period: 1m
     hard_delete_grace_period: 10m
     taint_effect: NoExecute
@@ -176,6 +178,34 @@ the node failed to register with Kubernetes in time.
 
 Having the scale up activity timeout isn't necessarily a bad thing, it just acts as a fail safe in case scaling 
 activities take too long so that the scale lock isn't permanently enabled.
+
+### `scale_up_failure_threshold` and `scale_up_failure_cooldown`
+
+These options enable a scale-up circuit breaker that stops Escalator from repeatedly raising the ASG desired count
+when the cloud provider cannot actually deliver new nodes (for example, when an instance type is temporarily out of
+capacity in an availability zone). Without it, Escalator keeps increasing the desired count every scan interval while
+pods stay pending, driving the desired count up to `max_nodes` even though no instances are launching.
+
+A scale-up is counted as failed when the running node count (the ASG actual size) has not reached the desired count
+requested by the previous scale-up by the time the next scale-up is evaluated. `scale_up_failure_threshold` is the
+number of consecutive failed scale-ups that trips the breaker. Once tripped, Escalator stops increasing the desired
+count for that node group. Untainting of existing tainted nodes is unaffected, so already-running capacity can still
+be reused.
+
+Because fulfilment is judged once per scale-up (which is itself paced by `scale_up_cool_down_period`), set the cooldown
+long enough for the cloud provider to launch and attach instances. The same guidance already applies to a healthy
+scale-up. If the cooldown is shorter than typical instance launch latency, a healthy-but-slow node group could be
+mistaken for a stuck one.
+
+`scale_up_failure_cooldown` is how long the breaker stays open before allowing a single half-open probe scale-up. If
+that probe also fails to reach its requested target, the breaker re-opens immediately; if running capacity has
+recovered, normal scaling resumes.
+
+The feature is opt-in and disabled by default. Leave `scale_up_failure_threshold` unset (or `0`) to disable it.
+`scale_up_failure_cooldown` must be a positive Go duration when `scale_up_failure_threshold` is greater than `0`.
+
+Two metrics are exported while this is enabled: `escalator_node_group_scale_up_circuit_breaker_open` (1 when open, 0
+when closed) and `escalator_node_group_scale_up_failed_scale_events` (count of failed scale-up requests).
 
 ### `soft_delete_grace_period` and `hard_delete_grace_period`
 

--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -181,27 +181,27 @@ activities take too long so that the scale lock isn't permanently enabled.
 ### `scale_up_failure_threshold`
 
 This option enables a scale-up circuit breaker that stops Escalator from repeatedly raising the ASG desired count
-when the cloud provider cannot actually deliver new nodes (for example, when an instance type is temporarily out of
-capacity in an availability zone). Without it, Escalator keeps increasing the desired count every scan interval while
-pods stay pending, driving the desired count up to `max_nodes` even though no instances are launching.
+when the cloud provider cannot deliver new nodes (for example, when an instance type is temporarily out of capacity in
+an availability zone). Without it, Escalator keeps increasing the desired count every scan interval while pods stay
+pending, driving the desired count up to `max_nodes` even though no instances are launching.
 
-A scale-up is counted as failed when the running count has not grown at all since the previous scale-up by the time the
-next scale-up is evaluated — the cloud provider delivered no new capacity in the interim. `scale_up_failure_threshold`
-is the number of consecutive failed scale-ups that trips the breaker. Once tripped, Escalator stops increasing the
-desired count for that node group. Untainting of existing tainted nodes is unaffected, so already-running capacity can
-still be reused.
+A scale-up is counted as failed when the running count has not grown since the previous scale-up by the time the next
+scale-up is evaluated. That means the cloud provider delivered no new capacity in the interim.
+`scale_up_failure_threshold` is the number of consecutive failed scale-ups that trips the breaker. Once tripped,
+Escalator stops increasing the desired count for that node group. Untainting of existing tainted nodes is unaffected,
+so already-running capacity can still be reused.
 
-Judging on "did the running count grow" rather than "did it reach the previous target" keeps a busy-but-healthy node
-group from tripping. A group whose desired count rises every scan while instances launch steadily (just slower than
-demand) is still making progress and does not accrue failures; only a group that adds no capacity at all does.
+Judging on whether the running count grew, rather than whether it reached the previous target, keeps a busy-but-healthy
+node group from tripping. A group whose desired count rises every scan while instances launch steadily, just slower
+than demand, is still making progress and does not accrue failures. Only a group that adds no capacity at all does.
 
 While the breaker is open there is no cooldown or waiting period. Escalator keeps looping and evaluating as normal, but
 holds the desired count steady rather than raising it further. When the running count catches up to the current desired
-count — that is, the cloud provider has finally delivered the capacity — the breaker closes and normal scaling resumes
-on the next scan. This means recovery is picked up as soon as capacity is available, without introducing scaling
-latency. The recovery check uses the *current* desired count, not a value frozen at trip time, so if the desired count
-is lowered externally while the breaker is open (a scale-down as demand falls, or a manual reset) the breaker still
-recovers instead of staying stuck.
+count, the cloud provider has finally delivered the capacity, so the breaker closes and normal scaling resumes on the
+next scan. Recovery is picked up as soon as capacity is available, without introducing scaling latency. The recovery
+check uses the current desired count, not a value frozen at trip time, so if the desired count is lowered externally
+while the breaker is open (a scale-down as demand falls, or a manual reset) the breaker still recovers instead of
+staying stuck.
 
 The "running count" here is the ASG's instance count (`Size()`), i.e. the instances the ASG has, not the number of
 Ready Kubernetes nodes. This targets the out-of-capacity case, where no instances launch at all. If instances launch
@@ -222,17 +222,17 @@ count stays at 100. The breaker is set to `scale_up_failure_threshold: 3`.
 | Time  | Desired (breaker disabled) | Desired (breaker enabled)                  | Running |
 |-------|----------------------------|--------------------------------------------|---------|
 | 00:00 | 150                        | 150                                        | 100     |
-| 05:00 | 200                        | 200 (failure 1 — running didn't grow)      | 100     |
+| 05:00 | 200                        | 200 (failure 1, running didn't grow)       | 100     |
 | 10:00 | 250                        | 250 (failure 2)                            | 100     |
-| 15:00 | 300                        | 250 (opens on failure 3 — desired held)    | 100     |
+| 15:00 | 300                        | 250 (opens on failure 3, desired held)     | 100     |
 | 25:00 | 400                        | 250 (held)                                 | 100     |
 | 45:00 | 600 (max)                  | 250 (held)                                 | 100     |
 | AZ recovers | 600 (500-node overshoot) | 250 (delivered), breaker closes       | 250     |
 
-With the breaker disabled the desired count climbs to the max of 600 while only 100 nodes run — a 500-node gap that all
-tries to launch at once when the AZ recovers, overshooting real demand. With the breaker it caps at 250 and holds
-there. When the AZ recovers, the 250 requested nodes launch, the running count catches up to the held desired count of
-250, the breaker closes, and scaling resumes against real demand.
+With the breaker disabled the desired count climbs to the max of 600 while only 100 nodes run. That is a 500-node gap
+where all of them try to launch at once when the AZ recovers and overshoot real demand. With the breaker it caps at 250
+and holds there. When the AZ recovers, the 250 requested nodes launch, the running count catches up to the held desired
+count of 250, the breaker closes, and scaling resumes against real demand.
 
 ### `soft_delete_grace_period` and `hard_delete_grace_period`
 

--- a/docs/configuration/nodegroup.md
+++ b/docs/configuration/nodegroup.md
@@ -185,26 +185,54 @@ when the cloud provider cannot actually deliver new nodes (for example, when an 
 capacity in an availability zone). Without it, Escalator keeps increasing the desired count every scan interval while
 pods stay pending, driving the desired count up to `max_nodes` even though no instances are launching.
 
-A scale-up is counted as failed when the running node count (the ASG actual size) has not reached the desired count
-requested by the previous scale-up by the time the next scale-up is evaluated. `scale_up_failure_threshold` is the
-number of consecutive failed scale-ups that trips the breaker. Once tripped, Escalator stops increasing the desired
-count for that node group. Untainting of existing tainted nodes is unaffected, so already-running capacity can still
-be reused.
+A scale-up is counted as failed when the running count has not grown at all since the previous scale-up by the time the
+next scale-up is evaluated — the cloud provider delivered no new capacity in the interim. `scale_up_failure_threshold`
+is the number of consecutive failed scale-ups that trips the breaker. Once tripped, Escalator stops increasing the
+desired count for that node group. Untainting of existing tainted nodes is unaffected, so already-running capacity can
+still be reused.
+
+Judging on "did the running count grow" rather than "did it reach the previous target" keeps a busy-but-healthy node
+group from tripping. A group whose desired count rises every scan while instances launch steadily (just slower than
+demand) is still making progress and does not accrue failures; only a group that adds no capacity at all does.
 
 While the breaker is open there is no cooldown or waiting period. Escalator keeps looping and evaluating as normal, but
-holds the desired count steady at the target it last requested. When the running count catches up to that frozen target
-— that is, the cloud provider has finally delivered the capacity — the breaker closes and normal scaling resumes on the
-next scan. This means recovery is picked up as soon as capacity is available, without introducing scaling latency.
+holds the desired count steady rather than raising it further. When the running count catches up to the current desired
+count — that is, the cloud provider has finally delivered the capacity — the breaker closes and normal scaling resumes
+on the next scan. This means recovery is picked up as soon as capacity is available, without introducing scaling
+latency. The recovery check uses the *current* desired count, not a value frozen at trip time, so if the desired count
+is lowered externally while the breaker is open (a scale-down as demand falls, or a manual reset) the breaker still
+recovers instead of staying stuck.
 
-Because fulfilment is judged once per scale-up (which is itself paced by `scale_up_cool_down_period`), set
-`scale_up_cool_down_period` long enough for the cloud provider to launch and attach instances. The same guidance already
-applies to a healthy scale-up. If it is shorter than typical instance launch latency, a healthy-but-slow node group
-could be mistaken for a stuck one.
+The "running count" here is the ASG's instance count (`Size()`), i.e. the instances the ASG has, not the number of
+Ready Kubernetes nodes. This targets the out-of-capacity case, where no instances launch at all. If instances launch
+but never join the cluster (for example a broken bootstrap), Escalator sees the count grow and treats that as capacity
+arriving, so the breaker will not trip on that failure mode.
 
 The feature is opt-in and disabled by default. Leave `scale_up_failure_threshold` unset (or `0`) to disable it.
 
 Two metrics are exported while this is enabled: `escalator_node_group_scale_up_circuit_breaker_open` (1 when open, 0
 when closed) and `escalator_node_group_scale_up_failed_scale_events` (count of failed scale-up requests).
+
+#### Worked example
+
+A node group with `max_nodes: 600`, running 100, `scale_up_cool_down_period: 5m`, wanting roughly +50 nodes each loop
+to clear a backlog of pending pods. An instance type is out of capacity in the AZ, so nothing launches and the running
+count stays at 100. The breaker is set to `scale_up_failure_threshold: 3`.
+
+| Time  | Desired (breaker disabled) | Desired (breaker enabled)                  | Running |
+|-------|----------------------------|--------------------------------------------|---------|
+| 00:00 | 150                        | 150                                        | 100     |
+| 05:00 | 200                        | 200 (failure 1 — running didn't grow)      | 100     |
+| 10:00 | 250                        | 250 (failure 2)                            | 100     |
+| 15:00 | 300                        | 250 (opens on failure 3 — desired held)    | 100     |
+| 25:00 | 400                        | 250 (held)                                 | 100     |
+| 45:00 | 600 (max)                  | 250 (held)                                 | 100     |
+| AZ recovers | 600 (500-node overshoot) | 250 (delivered), breaker closes       | 250     |
+
+With the breaker disabled the desired count climbs to the max of 600 while only 100 nodes run — a 500-node gap that all
+tries to launch at once when the AZ recovers, overshooting real demand. With the breaker it caps at 250 and holds
+there. When the AZ recovers, the 250 requested nodes launch, the running count catches up to the held desired count of
+250, the breaker closes, and scaling resumes against real demand.
 
 ### `soft_delete_grace_period` and `hard_delete_grace_period`
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -101,10 +101,7 @@ func NewController(opts Opts, stopChan <-chan struct{}) (*Controller, error) {
 				minimumLockDuration: nodeGroupOpts.ScaleUpCoolDownPeriodDuration(),
 				nodegroup:           nodeGroupOpts.Name,
 			},
-			scaleUpCircuitBreaker: scaleUpCircuitBreaker{
-				failureThreshold: nodeGroupOpts.ScaleUpFailureThreshold,
-				nodegroup:        nodeGroupOpts.Name,
-			},
+			scaleUpCircuitBreaker: newScaleUpCircuitBreaker(nodeGroupOpts.Name, nodeGroupOpts.ScaleUpFailureThreshold),
 			scaleDelta: 0,
 		}
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -103,7 +103,6 @@ func NewController(opts Opts, stopChan <-chan struct{}) (*Controller, error) {
 			},
 			scaleUpCircuitBreaker: scaleUpCircuitBreaker{
 				failureThreshold: nodeGroupOpts.ScaleUpFailureThreshold,
-				cooldown:         nodeGroupOpts.ScaleUpFailureCooldownDuration(),
 				nodegroup:        nodeGroupOpts.Name,
 			},
 			scaleDelta: 0,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -27,9 +27,10 @@ type Controller struct {
 // NodeGroupState contains everything about a node group in the current state of the application
 type NodeGroupState struct {
 	*NodeGroupLister
-	Opts        NodeGroupOptions
-	NodeInfoMap map[string]*k8s.NodeInfo
-	scaleUpLock scaleLock
+	Opts                  NodeGroupOptions
+	NodeInfoMap           map[string]*k8s.NodeInfo
+	scaleUpLock           scaleLock
+	scaleUpCircuitBreaker scaleUpCircuitBreaker
 
 	// used for tracking which nodes are tainted. testing when in dry mode
 	taintTracker      []string
@@ -99,6 +100,11 @@ func NewController(opts Opts, stopChan <-chan struct{}) (*Controller, error) {
 			scaleUpLock: scaleLock{
 				minimumLockDuration: nodeGroupOpts.ScaleUpCoolDownPeriodDuration(),
 				nodegroup:           nodeGroupOpts.Name,
+			},
+			scaleUpCircuitBreaker: scaleUpCircuitBreaker{
+				failureThreshold: nodeGroupOpts.ScaleUpFailureThreshold,
+				cooldown:         nodeGroupOpts.ScaleUpFailureCooldownDuration(),
+				nodegroup:        nodeGroupOpts.Name,
 			},
 			scaleDelta: 0,
 		}

--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -143,6 +143,8 @@ func ValidateNodeGroup(nodegroup NodeGroupOptions) []error {
 	checkThat(len(nodegroup.ScaleUpCoolDownPeriod) > 0, "scale_up_cool_down_period must not be empty")
 	checkThat(nodegroup.ScaleUpCoolDownPeriodDuration() > 0, "soft_delete_grace_period failed to parse into a time.Duration. check your formatting.")
 
+	checkThat(nodegroup.ScaleUpFailureThreshold >= 0, "scale_up_failure_threshold must be greater than or equal to 0")
+
 	checkThat(validTaintEffect(nodegroup.TaintEffect), "taint_effect must be valid kubernetes taint")
 
 	checkThat(validAWSLifecycle(nodegroup.AWS.Lifecycle), "aws.lifecycle must be '%v' or '%v' if provided.", aws.LifecycleOnDemand, aws.LifecycleSpot)
@@ -391,10 +393,7 @@ func BuildNodeGroupsState(opts nodeGroupsStateOpts) map[string]*NodeGroupState {
 				minimumLockDuration: ng.ScaleUpCoolDownPeriodDuration(),
 				nodegroup:           ng.Name,
 			},
-			scaleUpCircuitBreaker: scaleUpCircuitBreaker{
-				failureThreshold: ng.ScaleUpFailureThreshold,
-				nodegroup:        ng.Name,
-			},
+			scaleUpCircuitBreaker: newScaleUpCircuitBreaker(ng.Name, ng.ScaleUpFailureThreshold),
 		}
 	}
 	return nodeGroupsState

--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -65,12 +65,16 @@ type NodeGroupOptions struct {
 	// allowed in the nodegroup at any given time.
 	MaxUnhealthyNodesPercent int `json:"max_unhealthy_nodes_percent,omitempty" yaml:"max_unhealthy_nodes_percent,omitempty"`
 
+	ScaleUpFailureThreshold int    `json:"scale_up_failure_threshold,omitempty" yaml:"scale_up_failure_threshold,omitempty"`
+	ScaleUpFailureCooldown  string `json:"scale_up_failure_cooldown,omitempty" yaml:"scale_up_failure_cooldown,omitempty"`
+
 	// Private variables for storing the parsed duration from the string
 	softDeleteGracePeriodDuration    time.Duration
 	hardDeleteGracePeriodDuration    time.Duration
 	scaleUpCoolDownPeriodDuration    time.Duration
 	maxNodeAgeDuration               time.Duration
 	unhealthyNodeGracePeriodDuration time.Duration
+	scaleUpFailureCooldownDuration   time.Duration
 }
 
 // AWSNodeGroupOptions represents a nodegroup running on a cluster that is
@@ -156,6 +160,10 @@ func ValidateNodeGroup(nodegroup NodeGroupOptions) []error {
 		checkThat(nodegroup.MaxUnhealthyNodesPercent < 100, "max_unhealthy_nodes_percent must be less than 100")
 	}
 
+	if nodegroup.ScaleUpFailureThreshold > 0 {
+		checkThat(nodegroup.ScaleUpFailureCooldownDuration() > 0, "scale_up_failure_cooldown must be a positive Go duration when scale_up_failure_threshold is set")
+	}
+
 	return problems
 }
 
@@ -227,6 +235,19 @@ func (n *NodeGroupOptions) MaxNodeAgeDuration() time.Duration {
 	}
 
 	return n.maxNodeAgeDuration
+}
+
+// ScaleUpFailureCooldownDuration lazily returns/parses the scaleUpFailureCooldown string into a duration
+func (n *NodeGroupOptions) ScaleUpFailureCooldownDuration() time.Duration {
+	if n.scaleUpFailureCooldownDuration == 0 {
+		duration, err := time.ParseDuration(n.ScaleUpFailureCooldown)
+		if err != nil {
+			return 0
+		}
+		n.scaleUpFailureCooldownDuration = duration
+	}
+
+	return n.scaleUpFailureCooldownDuration
 }
 
 // UnhealthyNodeGracePeriodDuration lazily returns/parses the unhealthyNodeGracePeriod string into a duration
@@ -388,6 +409,11 @@ func BuildNodeGroupsState(opts nodeGroupsStateOpts) map[string]*NodeGroupState {
 			scaleUpLock: scaleLock{
 				minimumLockDuration: ng.ScaleUpCoolDownPeriodDuration(),
 				nodegroup:           ng.Name,
+			},
+			scaleUpCircuitBreaker: scaleUpCircuitBreaker{
+				failureThreshold: ng.ScaleUpFailureThreshold,
+				cooldown:         ng.ScaleUpFailureCooldownDuration(),
+				nodegroup:        ng.Name,
 			},
 		}
 	}

--- a/pkg/controller/node_group.go
+++ b/pkg/controller/node_group.go
@@ -65,8 +65,7 @@ type NodeGroupOptions struct {
 	// allowed in the nodegroup at any given time.
 	MaxUnhealthyNodesPercent int `json:"max_unhealthy_nodes_percent,omitempty" yaml:"max_unhealthy_nodes_percent,omitempty"`
 
-	ScaleUpFailureThreshold int    `json:"scale_up_failure_threshold,omitempty" yaml:"scale_up_failure_threshold,omitempty"`
-	ScaleUpFailureCooldown  string `json:"scale_up_failure_cooldown,omitempty" yaml:"scale_up_failure_cooldown,omitempty"`
+	ScaleUpFailureThreshold int `json:"scale_up_failure_threshold,omitempty" yaml:"scale_up_failure_threshold,omitempty"`
 
 	// Private variables for storing the parsed duration from the string
 	softDeleteGracePeriodDuration    time.Duration
@@ -74,7 +73,6 @@ type NodeGroupOptions struct {
 	scaleUpCoolDownPeriodDuration    time.Duration
 	maxNodeAgeDuration               time.Duration
 	unhealthyNodeGracePeriodDuration time.Duration
-	scaleUpFailureCooldownDuration   time.Duration
 }
 
 // AWSNodeGroupOptions represents a nodegroup running on a cluster that is
@@ -160,10 +158,6 @@ func ValidateNodeGroup(nodegroup NodeGroupOptions) []error {
 		checkThat(nodegroup.MaxUnhealthyNodesPercent < 100, "max_unhealthy_nodes_percent must be less than 100")
 	}
 
-	if nodegroup.ScaleUpFailureThreshold > 0 {
-		checkThat(nodegroup.ScaleUpFailureCooldownDuration() > 0, "scale_up_failure_cooldown must be a positive Go duration when scale_up_failure_threshold is set")
-	}
-
 	return problems
 }
 
@@ -235,19 +229,6 @@ func (n *NodeGroupOptions) MaxNodeAgeDuration() time.Duration {
 	}
 
 	return n.maxNodeAgeDuration
-}
-
-// ScaleUpFailureCooldownDuration lazily returns/parses the scaleUpFailureCooldown string into a duration
-func (n *NodeGroupOptions) ScaleUpFailureCooldownDuration() time.Duration {
-	if n.scaleUpFailureCooldownDuration == 0 {
-		duration, err := time.ParseDuration(n.ScaleUpFailureCooldown)
-		if err != nil {
-			return 0
-		}
-		n.scaleUpFailureCooldownDuration = duration
-	}
-
-	return n.scaleUpFailureCooldownDuration
 }
 
 // UnhealthyNodeGracePeriodDuration lazily returns/parses the unhealthyNodeGracePeriod string into a duration
@@ -412,7 +393,6 @@ func BuildNodeGroupsState(opts nodeGroupsStateOpts) map[string]*NodeGroupState {
 			},
 			scaleUpCircuitBreaker: scaleUpCircuitBreaker{
 				failureThreshold: ng.ScaleUpFailureThreshold,
-				cooldown:         ng.ScaleUpFailureCooldownDuration(),
 				nodegroup:        ng.Name,
 			},
 		}

--- a/pkg/controller/scale_up.go
+++ b/pkg/controller/scale_up.go
@@ -34,7 +34,11 @@ func (c *Controller) ScaleUp(opts scaleOpts) (int, error) {
 		return 0, err
 	}
 
-	opts.nodeGroup.scaleUpLock.lock(added)
+	// Only engage the scale lock when capacity was actually requested. A circuit
+	// breaker block returns zero and must not be recorded as an in-flight scale.
+	if added > 0 {
+		opts.nodeGroup.scaleUpLock.lock(added)
+	}
 	return untainted + added, nil
 }
 
@@ -69,6 +73,15 @@ func (c *Controller) scaleUpCloudProviderNodeGroup(opts scaleOpts) (int, error) 
 	}
 
 	if nodesToAdd > 0 {
+		// The breaker logs its own state transitions; keep this at debug to avoid
+		// repeating a warning on every scan while it stays open.
+		if !opts.nodeGroup.scaleUpCircuitBreaker.allow(cloudProviderNodeGroup.Size()) {
+			log.WithField("nodegroup", nodegroupName).
+				Debugf("scale-up circuit breaker open: refusing to increase desired count (target %v, running %v)",
+					cloudProviderNodeGroup.TargetSize(), cloudProviderNodeGroup.Size())
+			return 0, nil
+		}
+
 		drymode := c.dryMode(opts.nodeGroup)
 		log.WithField("drymode", drymode).
 			WithField("nodegroup", nodegroupName).
@@ -80,6 +93,7 @@ func (c *Controller) scaleUpCloudProviderNodeGroup(opts scaleOpts) (int, error) 
 				log.Errorf("failed to set cloud provider node group size: %v", err)
 				return 0, err
 			}
+			opts.nodeGroup.scaleUpCircuitBreaker.recordScaleUp(cloudProviderNodeGroup.TargetSize())
 		}
 	} else {
 		return 0, fmt.Errorf("adding %v nodes would breach max cloud provider node group size (%v)", nodesToAdd, cloudProviderNodeGroup.MaxSize())

--- a/pkg/controller/scale_up.go
+++ b/pkg/controller/scale_up.go
@@ -61,11 +61,17 @@ func (c *Controller) scaleUpCloudProviderNodeGroup(opts scaleOpts) (int, error) 
 	}
 
 	nodegroupName := opts.nodeGroup.Opts.Name
-	nodesToAdd := c.calculateNodesToAdd(int64(opts.nodesDelta), cloudProviderNodeGroup.TargetSize(), cloudProviderNodeGroup.MaxSize())
+	// Read the running and desired counts once, up front. On real AWS these
+	// reflect the values refreshed at the start of the scan; IncreaseSize only
+	// updates the remote desired capacity and does not refresh the local cache,
+	// so reading after the increase would return stale values.
+	currentSize := cloudProviderNodeGroup.Size()
+	targetSize := cloudProviderNodeGroup.TargetSize()
+	nodesToAdd := c.calculateNodesToAdd(int64(opts.nodesDelta), targetSize, cloudProviderNodeGroup.MaxSize())
 	if nodesToAdd <= 0 {
 		err := fmt.Errorf(
 			"refusing to scaleup up beyond the maximum size of the autoscaling group (TargetSize: %v; MaxNodes: %v). Taking no action",
-			cloudProviderNodeGroup.TargetSize(),
+			targetSize,
 			opts.nodeGroup.Opts.MaxNodes,
 		)
 		log.WithError(err).Error("Cancelling scaleup")
@@ -75,10 +81,10 @@ func (c *Controller) scaleUpCloudProviderNodeGroup(opts scaleOpts) (int, error) 
 	if nodesToAdd > 0 {
 		// The breaker logs its own state transitions; keep this at debug to avoid
 		// repeating a warning on every scan while it stays open.
-		if !opts.nodeGroup.scaleUpCircuitBreaker.allow(cloudProviderNodeGroup.Size()) {
+		if !opts.nodeGroup.scaleUpCircuitBreaker.allow(currentSize, targetSize) {
 			log.WithField("nodegroup", nodegroupName).
-				Debugf("scale-up circuit breaker open: refusing to increase desired count (target %v, running %v)",
-					cloudProviderNodeGroup.TargetSize(), cloudProviderNodeGroup.Size())
+				Debugf("scale-up circuit breaker open: refusing to increase desired count (desired %v, running %v)",
+					targetSize, currentSize)
 			return 0, nil
 		}
 
@@ -93,7 +99,9 @@ func (c *Controller) scaleUpCloudProviderNodeGroup(opts scaleOpts) (int, error) 
 				log.Errorf("failed to set cloud provider node group size: %v", err)
 				return 0, err
 			}
-			opts.nodeGroup.scaleUpCircuitBreaker.recordScaleUp(cloudProviderNodeGroup.TargetSize())
+			// Record the running count at scale-up time so the next scan can tell
+			// whether the cloud provider delivered any new capacity in between.
+			opts.nodeGroup.scaleUpCircuitBreaker.recordScaleUp(currentSize)
 		}
 	} else {
 		return 0, fmt.Errorf("adding %v nodes would breach max cloud provider node group size (%v)", nodesToAdd, cloudProviderNodeGroup.MaxSize())

--- a/pkg/controller/scale_up_circuit_breaker.go
+++ b/pkg/controller/scale_up_circuit_breaker.go
@@ -1,0 +1,109 @@
+package controller
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/atlassian/escalator/pkg/metrics"
+	log "github.com/sirupsen/logrus"
+)
+
+type circuitState int
+
+const (
+	circuitClosed circuitState = iota
+	circuitOpen
+)
+
+func (s circuitState) String() string {
+	switch s {
+	case circuitClosed:
+		return "closed"
+	case circuitOpen:
+		return "open"
+	default:
+		return "unknown"
+	}
+}
+
+type scaleUpCircuitBreaker struct {
+	failureThreshold int
+	cooldown         time.Duration
+	nodegroup        string
+
+	state               circuitState
+	consecutiveFailures int
+	lastRequestedTarget int64 // desired count requested at the last allowed scale-up
+	sawScaleUp          bool  // an allowed scale-up is awaiting a fulfilment judgement
+	openedAt            time.Time
+}
+
+func (b *scaleUpCircuitBreaker) enabled() bool {
+	return b.failureThreshold > 0
+}
+
+// allow returns true if a cloud-provider desired-count increase is permitted.
+// It judges the outcome of the previous allowed scale-up before deciding.
+func (b *scaleUpCircuitBreaker) allow(currentSize int64) bool {
+	if !b.enabled() {
+		return true
+	}
+
+	if b.sawScaleUp {
+		// The running count is expected to reach the desired count we requested
+		// within the scale-up cooldown. If it has not, the cloud provider could
+		// not deliver the capacity (e.g. AZ out of capacity), so count a failure.
+		if currentSize >= b.lastRequestedTarget {
+			b.consecutiveFailures = 0
+		} else {
+			b.consecutiveFailures++
+			metrics.NodeGroupScaleUpFailedScaleEvents.WithLabelValues(b.nodegroup).Add(1)
+		}
+		b.sawScaleUp = false
+	}
+
+	switch b.state {
+	case circuitClosed:
+		if b.consecutiveFailures >= b.failureThreshold {
+			b.state = circuitOpen
+			b.openedAt = time.Now()
+			metrics.NodeGroupScaleUpCircuitBreakerOpen.WithLabelValues(b.nodegroup).Set(1)
+			log.WithField("nodegroup", b.nodegroup).
+				Warnf("scale-up circuit breaker tripped after %d consecutive failures", b.consecutiveFailures)
+			return false
+		}
+		return true
+	case circuitOpen:
+		if time.Since(b.openedAt) >= b.cooldown {
+			b.state = circuitClosed
+			// One further failure re-trips immediately.
+			b.consecutiveFailures = b.failureThreshold - 1
+			metrics.NodeGroupScaleUpCircuitBreakerOpen.WithLabelValues(b.nodegroup).Set(0)
+			log.WithField("nodegroup", b.nodegroup).
+				Infof("scale-up circuit breaker half-open probe: allowing one request after cooldown")
+			return true
+		}
+		log.WithField("nodegroup", b.nodegroup).
+			Debugf("scale-up circuit breaker still open, %v remaining", b.cooldown-time.Since(b.openedAt))
+		return false
+	}
+
+	return true
+}
+
+// recordScaleUp notes the desired count we just requested so the next allow()
+// call can judge whether the running count actually reached it.
+func (b *scaleUpCircuitBreaker) recordScaleUp(requestedTarget int64) {
+	b.lastRequestedTarget = requestedTarget
+	b.sawScaleUp = true
+}
+
+func (b scaleUpCircuitBreaker) String() string {
+	return fmt.Sprintf(
+		"circuitBreaker(state=%v, consecutiveFailures=%d, lastRequestedTarget=%d, sawScaleUp=%v)",
+		b.state,
+		b.consecutiveFailures,
+		b.lastRequestedTarget,
+		b.sawScaleUp,
+	)
+}

--- a/pkg/controller/scale_up_circuit_breaker.go
+++ b/pkg/controller/scale_up_circuit_breaker.go
@@ -2,7 +2,6 @@ package controller
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/atlassian/escalator/pkg/metrics"
 	log "github.com/sirupsen/logrus"
@@ -28,14 +27,12 @@ func (s circuitState) String() string {
 
 type scaleUpCircuitBreaker struct {
 	failureThreshold int
-	cooldown         time.Duration
 	nodegroup        string
 
 	state               circuitState
 	consecutiveFailures int
 	lastRequestedTarget int64 // desired count requested at the last allowed scale-up
 	sawScaleUp          bool  // an allowed scale-up is awaiting a fulfilment judgement
-	openedAt            time.Time
 }
 
 func (b *scaleUpCircuitBreaker) enabled() bool {
@@ -44,6 +41,11 @@ func (b *scaleUpCircuitBreaker) enabled() bool {
 
 // allow returns true if a cloud-provider desired-count increase is permitted.
 // It judges the outcome of the previous allowed scale-up before deciding.
+//
+// The breaker has no cooldown timer. It keeps looping as normal while open and
+// simply refuses to raise the desired count until the running count catches up
+// to the target we last requested. Once the cloud provider delivers that
+// capacity, the breaker closes and normal scaling resumes.
 func (b *scaleUpCircuitBreaker) allow(currentSize int64) bool {
 	if !b.enabled() {
 		return true
@@ -66,7 +68,6 @@ func (b *scaleUpCircuitBreaker) allow(currentSize int64) bool {
 	case circuitClosed:
 		if b.consecutiveFailures >= b.failureThreshold {
 			b.state = circuitOpen
-			b.openedAt = time.Now()
 			metrics.NodeGroupScaleUpCircuitBreakerOpen.WithLabelValues(b.nodegroup).Set(1)
 			log.WithField("nodegroup", b.nodegroup).
 				Warnf("scale-up circuit breaker tripped after %d consecutive failures", b.consecutiveFailures)
@@ -74,17 +75,21 @@ func (b *scaleUpCircuitBreaker) allow(currentSize int64) bool {
 		}
 		return true
 	case circuitOpen:
-		if time.Since(b.openedAt) >= b.cooldown {
+		// Recovery is signalled by the running count reaching the desired count
+		// we froze at when the breaker tripped. No probing or waiting required:
+		// while open the desired count is held steady, so once the cloud provider
+		// delivers that capacity the running count catches up and we resume.
+		if currentSize >= b.lastRequestedTarget {
 			b.state = circuitClosed
-			// One further failure re-trips immediately.
-			b.consecutiveFailures = b.failureThreshold - 1
+			b.consecutiveFailures = 0
 			metrics.NodeGroupScaleUpCircuitBreakerOpen.WithLabelValues(b.nodegroup).Set(0)
 			log.WithField("nodegroup", b.nodegroup).
-				Infof("scale-up circuit breaker half-open probe: allowing one request after cooldown")
+				Infof("scale-up circuit breaker closed: running count reached the requested target, resuming scaling")
 			return true
 		}
 		log.WithField("nodegroup", b.nodegroup).
-			Debugf("scale-up circuit breaker still open, %v remaining", b.cooldown-time.Since(b.openedAt))
+			Debugf("scale-up circuit breaker still open: running %v has not reached requested target %v",
+				currentSize, b.lastRequestedTarget)
 		return false
 	}
 

--- a/pkg/controller/scale_up_circuit_breaker.go
+++ b/pkg/controller/scale_up_circuit_breaker.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"fmt"
-
 	"github.com/atlassian/escalator/pkg/metrics"
 	log "github.com/sirupsen/logrus"
 )
@@ -31,31 +29,52 @@ type scaleUpCircuitBreaker struct {
 
 	state               circuitState
 	consecutiveFailures int
-	lastRequestedTarget int64 // desired count requested at the last allowed scale-up
+	lastObservedSize    int64 // running count observed at the last allowed scale-up
 	sawScaleUp          bool  // an allowed scale-up is awaiting a fulfilment judgement
+}
+
+// newScaleUpCircuitBreaker builds a breaker for a node group. When enabled it
+// seeds the "open" gauge to 0 so dashboards have a baseline line to sit on even
+// for a group that never trips.
+func newScaleUpCircuitBreaker(nodegroup string, failureThreshold int) scaleUpCircuitBreaker {
+	b := scaleUpCircuitBreaker{
+		failureThreshold: failureThreshold,
+		nodegroup:        nodegroup,
+	}
+	if b.enabled() {
+		metrics.NodeGroupScaleUpCircuitBreakerOpen.WithLabelValues(nodegroup).Set(0)
+	}
+	return b
 }
 
 func (b *scaleUpCircuitBreaker) enabled() bool {
 	return b.failureThreshold > 0
 }
 
-// allow returns true if a cloud-provider desired-count increase is permitted.
-// It judges the outcome of the previous allowed scale-up before deciding.
+// allow reports whether a cloud-provider desired-count increase is permitted.
+// currentSize is the running count (the ASG actual size) and targetSize is the
+// current desired count. It judges the outcome of the previous allowed scale-up
+// before deciding.
+//
+// A scale-up is judged a failure only when the running count has not grown since
+// the previous allowed scale-up: the cloud provider delivered no new capacity
+// (e.g. an AZ is out of capacity). A group whose running count is still climbing,
+// even slowly and even while desired keeps rising, is considered healthy and does
+// not accrue failures.
 //
 // The breaker has no cooldown timer. It keeps looping as normal while open and
-// simply refuses to raise the desired count until the running count catches up
-// to the target we last requested. Once the cloud provider delivers that
-// capacity, the breaker closes and normal scaling resumes.
-func (b *scaleUpCircuitBreaker) allow(currentSize int64) bool {
+// simply refuses to raise the desired count until the running count catches up to
+// the current desired count. Once the cloud provider delivers that capacity, the
+// breaker closes and normal scaling resumes.
+func (b *scaleUpCircuitBreaker) allow(currentSize, targetSize int64) bool {
 	if !b.enabled() {
 		return true
 	}
 
 	if b.sawScaleUp {
-		// The running count is expected to reach the desired count we requested
-		// within the scale-up cooldown. If it has not, the cloud provider could
-		// not deliver the capacity (e.g. AZ out of capacity), so count a failure.
-		if currentSize >= b.lastRequestedTarget {
+		if currentSize > b.lastObservedSize {
+			// Running count grew since the last scale-up: the cloud provider is
+			// delivering capacity, so reset the failure count.
 			b.consecutiveFailures = 0
 		} else {
 			b.consecutiveFailures++
@@ -75,40 +94,34 @@ func (b *scaleUpCircuitBreaker) allow(currentSize int64) bool {
 		}
 		return true
 	case circuitOpen:
-		// Recovery is signalled by the running count reaching the desired count
-		// we froze at when the breaker tripped. No probing or waiting required:
-		// while open the desired count is held steady, so once the cloud provider
-		// delivers that capacity the running count catches up and we resume.
-		if currentSize >= b.lastRequestedTarget {
+		// Recovery is signalled by the running count catching up to the current
+		// desired count. No probing or waiting required: while open the desired
+		// count is held steady, so once the cloud provider delivers that capacity
+		// the running count catches up and we resume. Comparing against the live
+		// desired count (rather than a value frozen at trip time) means an external
+		// scale-down or a manual reset of the desired count also lets the breaker
+		// recover, instead of leaving it stuck open until a restart.
+		if currentSize >= targetSize {
 			b.state = circuitClosed
 			b.consecutiveFailures = 0
 			metrics.NodeGroupScaleUpCircuitBreakerOpen.WithLabelValues(b.nodegroup).Set(0)
 			log.WithField("nodegroup", b.nodegroup).
-				Infof("scale-up circuit breaker closed: running count reached the requested target, resuming scaling")
+				Infof("scale-up circuit breaker closed: running count caught up to desired, resuming scaling")
 			return true
 		}
 		log.WithField("nodegroup", b.nodegroup).
-			Debugf("scale-up circuit breaker still open: running %v has not reached requested target %v",
-				currentSize, b.lastRequestedTarget)
+			Debugf("scale-up circuit breaker still open: running %v has not reached desired %v",
+				currentSize, targetSize)
 		return false
 	}
 
 	return true
 }
 
-// recordScaleUp notes the desired count we just requested so the next allow()
-// call can judge whether the running count actually reached it.
-func (b *scaleUpCircuitBreaker) recordScaleUp(requestedTarget int64) {
-	b.lastRequestedTarget = requestedTarget
+// recordScaleUp notes the running count at the moment of an allowed scale-up so
+// the next allow() call can tell whether the cloud provider delivered any new
+// capacity in the interim.
+func (b *scaleUpCircuitBreaker) recordScaleUp(observedSize int64) {
+	b.lastObservedSize = observedSize
 	b.sawScaleUp = true
-}
-
-func (b scaleUpCircuitBreaker) String() string {
-	return fmt.Sprintf(
-		"circuitBreaker(state=%v, consecutiveFailures=%d, lastRequestedTarget=%d, sawScaleUp=%v)",
-		b.state,
-		b.consecutiveFailures,
-		b.lastRequestedTarget,
-		b.sawScaleUp,
-	)
 }

--- a/pkg/controller/scale_up_circuit_breaker_test.go
+++ b/pkg/controller/scale_up_circuit_breaker_test.go
@@ -1,0 +1,131 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestBreaker(threshold int, cooldown time.Duration) *scaleUpCircuitBreaker {
+	return &scaleUpCircuitBreaker{
+		failureThreshold: threshold,
+		cooldown:         cooldown,
+		nodegroup:        "test-ng",
+	}
+}
+
+func TestCircuitBreakerDisabled(t *testing.T) {
+	b := newTestBreaker(0, time.Minute)
+	for i := 0; i < 10; i++ {
+		assert.True(t, b.allow(int64(i)), "disabled breaker must always allow")
+	}
+}
+
+func TestCircuitBreakerClosedResetsOnFulfilment(t *testing.T) {
+	b := newTestBreaker(3, time.Minute)
+
+	// First call has no prior request to judge.
+	assert.True(t, b.allow(10))
+	b.recordScaleUp(12)
+
+	// Running count reached the requested target: failure count resets.
+	assert.True(t, b.allow(12))
+	assert.Equal(t, 0, b.consecutiveFailures)
+	b.recordScaleUp(14)
+
+	assert.True(t, b.allow(14))
+	assert.Equal(t, 0, b.consecutiveFailures)
+}
+
+func TestCircuitBreakerTripsAfterThreshold(t *testing.T) {
+	b := newTestBreaker(3, time.Minute)
+
+	// Running count is stuck at 10 while each request raises the target.
+	assert.True(t, b.allow(10))
+	b.recordScaleUp(12)
+	assert.True(t, b.allow(10)) // 10 < 12 → failure 1
+	b.recordScaleUp(14)
+	assert.True(t, b.allow(10)) // failure 2
+	b.recordScaleUp(16)
+	assert.False(t, b.allow(10)) // failure 3 → trips
+	assert.Equal(t, circuitOpen, b.state)
+
+	assert.False(t, b.allow(10))
+}
+
+func TestCircuitBreakerOpenBlocksUntilCooldown(t *testing.T) {
+	b := newTestBreaker(2, 5*time.Minute)
+
+	assert.True(t, b.allow(10))
+	b.recordScaleUp(12)
+	assert.True(t, b.allow(10)) // failure 1
+	b.recordScaleUp(14)
+	assert.False(t, b.allow(10)) // failure 2 → trips
+
+	assert.False(t, b.allow(10))
+	assert.False(t, b.allow(10))
+
+	// Simulate cooldown elapsed by backdating openedAt.
+	b.openedAt = time.Now().Add(-6 * time.Minute)
+
+	assert.True(t, b.allow(10)) // half-open probe
+	assert.Equal(t, circuitClosed, b.state)
+}
+
+func TestCircuitBreakerHalfOpenRetripsOnFailure(t *testing.T) {
+	b := newTestBreaker(2, 5*time.Minute)
+
+	assert.True(t, b.allow(10))
+	b.recordScaleUp(12)
+	assert.True(t, b.allow(10)) // failure 1
+	b.recordScaleUp(14)
+	assert.False(t, b.allow(10)) // failure 2 → trips
+
+	b.openedAt = time.Now().Add(-6 * time.Minute)
+
+	assert.True(t, b.allow(10)) // half-open probe
+	assert.Equal(t, circuitClosed, b.state)
+	assert.Equal(t, b.failureThreshold-1, b.consecutiveFailures)
+
+	b.recordScaleUp(16)
+
+	// Target still unmet → a single further failure re-trips immediately.
+	assert.False(t, b.allow(10))
+	assert.Equal(t, circuitOpen, b.state)
+}
+
+func TestCircuitBreakerHalfOpenRecovers(t *testing.T) {
+	b := newTestBreaker(2, 5*time.Minute)
+
+	assert.True(t, b.allow(10))
+	b.recordScaleUp(12)
+	assert.True(t, b.allow(10)) // failure 1
+	b.recordScaleUp(14)
+	assert.False(t, b.allow(10)) // failure 2 → trips
+
+	b.openedAt = time.Now().Add(-6 * time.Minute)
+
+	assert.True(t, b.allow(10)) // half-open probe
+	b.recordScaleUp(16)
+
+	// Capacity recovered: running count reached the requested target.
+	assert.True(t, b.allow(16))
+	assert.Equal(t, circuitClosed, b.state)
+	assert.Equal(t, 0, b.consecutiveFailures)
+}
+
+func TestCircuitBreakerFailedScaleEventCounter(t *testing.T) {
+	b := newTestBreaker(5, time.Minute)
+
+	assert.True(t, b.allow(10))
+	b.recordScaleUp(12)
+
+	for i := 0; i < 3; i++ {
+		b.allow(10) // 10 < 12 → failure
+		if i < 2 {
+			b.recordScaleUp(12)
+		}
+	}
+	assert.Equal(t, 3, b.consecutiveFailures)
+}

--- a/pkg/controller/scale_up_circuit_breaker_test.go
+++ b/pkg/controller/scale_up_circuit_breaker_test.go
@@ -7,98 +7,134 @@ import (
 )
 
 func newTestBreaker(threshold int) *scaleUpCircuitBreaker {
-	return &scaleUpCircuitBreaker{
-		failureThreshold: threshold,
-		nodegroup:        "test-ng",
-	}
+	b := newScaleUpCircuitBreaker("test-ng", threshold)
+	return &b
 }
 
 func TestCircuitBreakerDisabled(t *testing.T) {
 	b := newTestBreaker(0)
 	for i := 0; i < 10; i++ {
-		assert.True(t, b.allow(int64(i)), "disabled breaker must always allow")
+		assert.True(t, b.allow(int64(i), int64(i+5)), "disabled breaker must always allow")
 	}
 }
 
-func TestCircuitBreakerClosedResetsOnFulfilment(t *testing.T) {
+func TestCircuitBreakerResetsWhenRunningGrows(t *testing.T) {
 	b := newTestBreaker(3)
 
-	// First call has no prior request to judge.
-	assert.True(t, b.allow(10))
-	b.recordScaleUp(12)
+	// First call has no prior scale-up to judge.
+	assert.True(t, b.allow(10, 12))
+	b.recordScaleUp(10)
 
-	// Running count reached the requested target: failure count resets.
-	assert.True(t, b.allow(12))
+	// Running count grew since the last scale-up: capacity is being delivered, so
+	// the failure count resets.
+	assert.True(t, b.allow(11, 14))
 	assert.Equal(t, 0, b.consecutiveFailures)
-	b.recordScaleUp(14)
+	b.recordScaleUp(11)
 
-	assert.True(t, b.allow(14))
+	assert.True(t, b.allow(12, 16))
+	assert.Equal(t, 0, b.consecutiveFailures)
+}
+
+// A busy cluster whose desired count rises faster than instances launch is still
+// healthy as long as the running count keeps climbing, and must not trip.
+func TestCircuitBreakerDoesNotTripWhenRunningKeepsGrowing(t *testing.T) {
+	b := newTestBreaker(2)
+
+	assert.True(t, b.allow(10, 15))
+	b.recordScaleUp(10)
+	assert.True(t, b.allow(11, 20)) // running 10 -> 11, progress
+	b.recordScaleUp(11)
+	assert.True(t, b.allow(12, 25)) // running 11 -> 12, progress
+	b.recordScaleUp(12)
+	assert.True(t, b.allow(13, 30)) // running 12 -> 13, progress
+
+	assert.Equal(t, circuitClosed, b.state)
 	assert.Equal(t, 0, b.consecutiveFailures)
 }
 
 func TestCircuitBreakerTripsAfterThreshold(t *testing.T) {
 	b := newTestBreaker(3)
 
-	// Running count is stuck at 10 while each request raises the target.
-	assert.True(t, b.allow(10))
-	b.recordScaleUp(12)
-	assert.True(t, b.allow(10)) // 10 < 12 → failure 1
-	b.recordScaleUp(14)
-	assert.True(t, b.allow(10)) // failure 2
-	b.recordScaleUp(16)
-	assert.False(t, b.allow(10)) // failure 3 → trips
+	// Running count is stuck at 10 while each scale-up raises the desired count.
+	assert.True(t, b.allow(10, 12))
+	b.recordScaleUp(10)
+	assert.True(t, b.allow(10, 14)) // running didn't grow -> failure 1
+	b.recordScaleUp(10)
+	assert.True(t, b.allow(10, 16)) // failure 2
+	b.recordScaleUp(10)
+	assert.False(t, b.allow(10, 18)) // failure 3 -> trips
 	assert.Equal(t, circuitOpen, b.state)
 
-	assert.False(t, b.allow(10))
+	assert.False(t, b.allow(10, 18))
 }
 
-func TestCircuitBreakerStaysOpenUntilRunningReachesTarget(t *testing.T) {
+func TestCircuitBreakerStaysOpenUntilRunningReachesDesired(t *testing.T) {
 	b := newTestBreaker(2)
 
-	assert.True(t, b.allow(10))
-	b.recordScaleUp(12)
-	assert.True(t, b.allow(10)) // failure 1
-	b.recordScaleUp(14)
-	assert.False(t, b.allow(10)) // failure 2 → trips, desired frozen at 14
+	assert.True(t, b.allow(10, 12))
+	b.recordScaleUp(10)
+	assert.True(t, b.allow(10, 14)) // failure 1
+	b.recordScaleUp(10)
+	assert.False(t, b.allow(10, 16)) // failure 2 -> trips, desired 16
 	assert.Equal(t, circuitOpen, b.state)
 
-	// Running count still below the frozen target: stays open, no probing.
-	assert.False(t, b.allow(11))
-	assert.False(t, b.allow(13))
+	// Running count still below desired: stays open, no probing.
+	assert.False(t, b.allow(11, 16))
+	assert.False(t, b.allow(15, 16))
 	assert.Equal(t, circuitOpen, b.state)
 }
 
 func TestCircuitBreakerRecoversWhenRunningCatchesUp(t *testing.T) {
 	b := newTestBreaker(2)
 
-	assert.True(t, b.allow(10))
-	b.recordScaleUp(12)
-	assert.True(t, b.allow(10)) // failure 1
-	b.recordScaleUp(14)
-	assert.False(t, b.allow(10)) // failure 2 → trips, desired frozen at 14
+	assert.True(t, b.allow(10, 12))
+	b.recordScaleUp(10)
+	assert.True(t, b.allow(10, 14)) // failure 1
+	b.recordScaleUp(10)
+	assert.False(t, b.allow(10, 16)) // failure 2 -> trips, desired 16
 
-	// Cloud provider finally delivers the capacity: running reaches the frozen
-	// target, so the breaker closes and scaling resumes.
-	assert.True(t, b.allow(14))
+	// Cloud provider finally delivers the capacity: running reaches desired, so
+	// the breaker closes and scaling resumes.
+	assert.True(t, b.allow(16, 16))
 	assert.Equal(t, circuitClosed, b.state)
 	assert.Equal(t, 0, b.consecutiveFailures)
 
 	// Normal scaling continues from here.
 	b.recordScaleUp(16)
-	assert.True(t, b.allow(16))
+	assert.True(t, b.allow(18, 20))
+	assert.Equal(t, 0, b.consecutiveFailures)
+}
+
+// Comparing against the live desired count (not a value frozen at trip time)
+// means the breaker recovers if desired is lowered externally while it is open
+// — a scale-down as demand falls, or a manual reset of the desired count.
+func TestCircuitBreakerRecoversWhenDesiredDropsWhileOpen(t *testing.T) {
+	b := newTestBreaker(2)
+
+	assert.True(t, b.allow(10, 12))
+	b.recordScaleUp(10)
+	assert.True(t, b.allow(10, 14)) // failure 1
+	b.recordScaleUp(10)
+	assert.False(t, b.allow(10, 16)) // failure 2 -> trips, desired 16
+	assert.Equal(t, circuitOpen, b.state)
+
+	// Desired is lowered to a value the running count already meets: recover
+	// rather than staying stuck open until a restart.
+	assert.True(t, b.allow(10, 10))
+	assert.Equal(t, circuitClosed, b.state)
 	assert.Equal(t, 0, b.consecutiveFailures)
 }
 
 func TestCircuitBreakerFailedScaleEventCounter(t *testing.T) {
 	b := newTestBreaker(5)
 
-	assert.True(t, b.allow(10))
-	b.recordScaleUp(12)
+	assert.True(t, b.allow(10, 12))
+	b.recordScaleUp(10)
 
 	for i := 0; i < 3; i++ {
-		b.allow(10) // 10 < 12 → failure
+		b.allow(10, 12) // running stuck at 10 -> failure
 		if i < 2 {
-			b.recordScaleUp(12)
+			b.recordScaleUp(10)
 		}
 	}
 	assert.Equal(t, 3, b.consecutiveFailures)

--- a/pkg/controller/scale_up_circuit_breaker_test.go
+++ b/pkg/controller/scale_up_circuit_breaker_test.go
@@ -2,28 +2,26 @@ package controller
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestBreaker(threshold int, cooldown time.Duration) *scaleUpCircuitBreaker {
+func newTestBreaker(threshold int) *scaleUpCircuitBreaker {
 	return &scaleUpCircuitBreaker{
 		failureThreshold: threshold,
-		cooldown:         cooldown,
 		nodegroup:        "test-ng",
 	}
 }
 
 func TestCircuitBreakerDisabled(t *testing.T) {
-	b := newTestBreaker(0, time.Minute)
+	b := newTestBreaker(0)
 	for i := 0; i < 10; i++ {
 		assert.True(t, b.allow(int64(i)), "disabled breaker must always allow")
 	}
 }
 
 func TestCircuitBreakerClosedResetsOnFulfilment(t *testing.T) {
-	b := newTestBreaker(3, time.Minute)
+	b := newTestBreaker(3)
 
 	// First call has no prior request to judge.
 	assert.True(t, b.allow(10))
@@ -39,7 +37,7 @@ func TestCircuitBreakerClosedResetsOnFulfilment(t *testing.T) {
 }
 
 func TestCircuitBreakerTripsAfterThreshold(t *testing.T) {
-	b := newTestBreaker(3, time.Minute)
+	b := newTestBreaker(3)
 
 	// Running count is stuck at 10 while each request raises the target.
 	assert.True(t, b.allow(10))
@@ -54,69 +52,45 @@ func TestCircuitBreakerTripsAfterThreshold(t *testing.T) {
 	assert.False(t, b.allow(10))
 }
 
-func TestCircuitBreakerOpenBlocksUntilCooldown(t *testing.T) {
-	b := newTestBreaker(2, 5*time.Minute)
+func TestCircuitBreakerStaysOpenUntilRunningReachesTarget(t *testing.T) {
+	b := newTestBreaker(2)
 
 	assert.True(t, b.allow(10))
 	b.recordScaleUp(12)
 	assert.True(t, b.allow(10)) // failure 1
 	b.recordScaleUp(14)
-	assert.False(t, b.allow(10)) // failure 2 → trips
+	assert.False(t, b.allow(10)) // failure 2 → trips, desired frozen at 14
+	assert.Equal(t, circuitOpen, b.state)
 
-	assert.False(t, b.allow(10))
-	assert.False(t, b.allow(10))
-
-	// Simulate cooldown elapsed by backdating openedAt.
-	b.openedAt = time.Now().Add(-6 * time.Minute)
-
-	assert.True(t, b.allow(10)) // half-open probe
-	assert.Equal(t, circuitClosed, b.state)
-}
-
-func TestCircuitBreakerHalfOpenRetripsOnFailure(t *testing.T) {
-	b := newTestBreaker(2, 5*time.Minute)
-
-	assert.True(t, b.allow(10))
-	b.recordScaleUp(12)
-	assert.True(t, b.allow(10)) // failure 1
-	b.recordScaleUp(14)
-	assert.False(t, b.allow(10)) // failure 2 → trips
-
-	b.openedAt = time.Now().Add(-6 * time.Minute)
-
-	assert.True(t, b.allow(10)) // half-open probe
-	assert.Equal(t, circuitClosed, b.state)
-	assert.Equal(t, b.failureThreshold-1, b.consecutiveFailures)
-
-	b.recordScaleUp(16)
-
-	// Target still unmet → a single further failure re-trips immediately.
-	assert.False(t, b.allow(10))
+	// Running count still below the frozen target: stays open, no probing.
+	assert.False(t, b.allow(11))
+	assert.False(t, b.allow(13))
 	assert.Equal(t, circuitOpen, b.state)
 }
 
-func TestCircuitBreakerHalfOpenRecovers(t *testing.T) {
-	b := newTestBreaker(2, 5*time.Minute)
+func TestCircuitBreakerRecoversWhenRunningCatchesUp(t *testing.T) {
+	b := newTestBreaker(2)
 
 	assert.True(t, b.allow(10))
 	b.recordScaleUp(12)
 	assert.True(t, b.allow(10)) // failure 1
 	b.recordScaleUp(14)
-	assert.False(t, b.allow(10)) // failure 2 → trips
+	assert.False(t, b.allow(10)) // failure 2 → trips, desired frozen at 14
 
-	b.openedAt = time.Now().Add(-6 * time.Minute)
-
-	assert.True(t, b.allow(10)) // half-open probe
-	b.recordScaleUp(16)
-
-	// Capacity recovered: running count reached the requested target.
-	assert.True(t, b.allow(16))
+	// Cloud provider finally delivers the capacity: running reaches the frozen
+	// target, so the breaker closes and scaling resumes.
+	assert.True(t, b.allow(14))
 	assert.Equal(t, circuitClosed, b.state)
+	assert.Equal(t, 0, b.consecutiveFailures)
+
+	// Normal scaling continues from here.
+	b.recordScaleUp(16)
+	assert.True(t, b.allow(16))
 	assert.Equal(t, 0, b.consecutiveFailures)
 }
 
 func TestCircuitBreakerFailedScaleEventCounter(t *testing.T) {
-	b := newTestBreaker(5, time.Minute)
+	b := newTestBreaker(5)
 
 	assert.True(t, b.allow(10))
 	b.recordScaleUp(12)

--- a/pkg/controller/scale_up_test.go
+++ b/pkg/controller/scale_up_test.go
@@ -249,7 +249,6 @@ func TestScaleUpCircuitBreakerIntegration(t *testing.T) {
 		MaxNodes:                maxNodes,
 		ScaleUpThresholdPercent: 70,
 		ScaleUpFailureThreshold: threshold,
-		ScaleUpFailureCooldown:  "10m",
 	}
 	nodeGroups := []NodeGroupOptions{nodeGroup}
 
@@ -297,13 +296,22 @@ func TestScaleUpCircuitBreakerIntegration(t *testing.T) {
 	assert.Equal(t, 0, added, "breaker should block the scale-up")
 	assert.Equal(t, lastPermittedTarget, cloudNG.TargetSize(), "TargetSize must be frozen after breaker trips")
 
-	// Further calls must also be blocked.
+	// Further calls must also be blocked while the running count stays behind
+	// the frozen target. There is no cooldown timer to wait out.
 	for i := 0; i < 3; i++ {
 		added, err = controller.scaleUpCloudProviderNodeGroup(opts)
 		assert.NoError(t, err)
 		assert.Equal(t, 0, added)
 		assert.Equal(t, lastPermittedTarget, cloudNG.TargetSize())
 	}
+
+	// The cloud provider finally delivers capacity: the running count catches up
+	// to the frozen target, so the breaker closes and scaling resumes.
+	cloudNG.SetActualSize(lastPermittedTarget)
+	added, err = controller.scaleUpCloudProviderNodeGroup(opts)
+	assert.NoError(t, err)
+	assert.Greater(t, added, 0, "breaker should resume once running reaches the frozen target")
+	assert.Greater(t, cloudNG.TargetSize(), lastPermittedTarget, "TargetSize should increase again after recovery")
 }
 
 func TestCalculateNodesToAdd(t *testing.T) {

--- a/pkg/controller/scale_up_test.go
+++ b/pkg/controller/scale_up_test.go
@@ -233,6 +233,79 @@ func TestControllerUntaintNewestN(t *testing.T) {
 	}
 }
 
+// TestScaleUpCircuitBreakerIntegration verifies that repeated stuck scale-ups
+// eventually stop increasing TargetSize once the breaker trips.
+func TestScaleUpCircuitBreakerIntegration(t *testing.T) {
+	const (
+		minNodes  = 2
+		maxNodes  = 20
+		threshold = 3
+	)
+
+	nodeGroup := NodeGroupOptions{
+		Name:                    "default",
+		CloudProviderGroupName:  "default",
+		MinNodes:                minNodes,
+		MaxNodes:                maxNodes,
+		ScaleUpThresholdPercent: 70,
+		ScaleUpFailureThreshold: threshold,
+		ScaleUpFailureCooldown:  "10m",
+	}
+	nodeGroups := []NodeGroupOptions{nodeGroup}
+
+	testCloudProvider := test.NewCloudProvider(1)
+	cloudNG := test.NewNodeGroup(
+		nodeGroup.CloudProviderGroupName,
+		nodeGroup.Name,
+		int64(minNodes),
+		int64(maxNodes),
+		int64(minNodes),
+	)
+	// Decouple actual from desired so IncreaseSize raises TargetSize but Size() stays fixed.
+	cloudNG.SetDecoupleActual(true)
+	cloudNG.SetActualSize(int64(minNodes))
+	testCloudProvider.RegisterNodeGroup(cloudNG)
+
+	nodeGroupsState := BuildNodeGroupsState(nodeGroupsStateOpts{
+		nodeGroups: nodeGroups,
+	})
+
+	controller := &Controller{
+		Opts:          Opts{NodeGroups: nodeGroups, DryMode: false},
+		nodeGroups:    nodeGroupsState,
+		cloudProvider: testCloudProvider,
+	}
+
+	opts := scaleOpts{
+		nodesDelta: 2,
+		nodeGroup:  nodeGroupsState[nodeGroup.Name],
+	}
+
+	// The first `threshold` scale-ups are permitted; each one raises TargetSize
+	// but Size() stays at minNodes (ASG stuck).
+	var lastPermittedTarget int64
+	for i := 0; i < threshold; i++ {
+		added, err := controller.scaleUpCloudProviderNodeGroup(opts)
+		assert.NoError(t, err)
+		assert.Greater(t, added, 0, "iteration %d should be permitted", i)
+		lastPermittedTarget = cloudNG.TargetSize()
+	}
+
+	// The next call must be blocked (breaker tripped).
+	added, err := controller.scaleUpCloudProviderNodeGroup(opts)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, added, "breaker should block the scale-up")
+	assert.Equal(t, lastPermittedTarget, cloudNG.TargetSize(), "TargetSize must be frozen after breaker trips")
+
+	// Further calls must also be blocked.
+	for i := 0; i < 3; i++ {
+		added, err = controller.scaleUpCloudProviderNodeGroup(opts)
+		assert.NoError(t, err)
+		assert.Equal(t, 0, added)
+		assert.Equal(t, lastPermittedTarget, cloudNG.TargetSize())
+	}
+}
+
 func TestCalculateNodesToAdd(t *testing.T) {
 
 	type args struct {

--- a/pkg/controller/scale_up_test.go
+++ b/pkg/controller/scale_up_test.go
@@ -281,7 +281,7 @@ func TestScaleUpCircuitBreakerIntegration(t *testing.T) {
 	}
 
 	// The first `threshold` scale-ups are permitted; each one raises TargetSize
-	// but Size() stays at minNodes (ASG stuck).
+	// but Size() stays at minNodes, so the running count never grows (ASG stuck).
 	var lastPermittedTarget int64
 	for i := 0; i < threshold; i++ {
 		added, err := controller.scaleUpCloudProviderNodeGroup(opts)
@@ -306,7 +306,7 @@ func TestScaleUpCircuitBreakerIntegration(t *testing.T) {
 	}
 
 	// The cloud provider finally delivers capacity: the running count catches up
-	// to the frozen target, so the breaker closes and scaling resumes.
+	// to the (frozen) desired count, so the breaker closes and scaling resumes.
 	cloudNG.SetActualSize(lastPermittedTarget)
 	added, err = controller.scaleUpCloudProviderNodeGroup(opts)
 	assert.NoError(t, err)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -335,6 +335,24 @@ var (
 		},
 		[]string{"node_group", "node"},
 	)
+	// NodeGroupScaleUpCircuitBreakerOpen indicates if the scale-up circuit breaker is open (1) or closed (0)
+	NodeGroupScaleUpCircuitBreakerOpen = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name:      "node_group_scale_up_circuit_breaker_open",
+			Namespace: NAMESPACE,
+			Help:      "indicates if the scale-up circuit breaker is open (1) or closed (0)",
+		},
+		[]string{"node_group"},
+	)
+	// NodeGroupScaleUpFailedScaleEvents counts scale-up requests where the running node count did not reach the requested target
+	NodeGroupScaleUpFailedScaleEvents = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name:      "node_group_scale_up_failed_scale_events",
+			Namespace: NAMESPACE,
+			Help:      "number of scale-up requests where the running node count did not reach the requested target size",
+		},
+		[]string{"node_group"},
+	)
 )
 
 func init() {
@@ -372,6 +390,8 @@ func init() {
 	prometheus.MustRegister(CloudProviderTargetSize)
 	prometheus.MustRegister(CloudProviderSize)
 	prometheus.MustRegister(NodeDeleteErrors)
+	prometheus.MustRegister(NodeGroupScaleUpCircuitBreakerOpen)
+	prometheus.MustRegister(NodeGroupScaleUpFailedScaleEvents)
 }
 
 // Start starts the metrics endpoint on a new routine

--- a/pkg/test/cloud_provider.go
+++ b/pkg/test/cloud_provider.go
@@ -79,23 +79,24 @@ func (i Instance) ID() string {
 
 // NodeGroup is a mock implementation of NodeGroup for testing
 type NodeGroup struct {
-	id         string
-	name       string
-	minSize    int64
-	maxSize    int64
-	actualSize int64
-	targetSize int64
+	id             string
+	name           string
+	minSize        int64
+	maxSize        int64
+	actualSize     int64
+	targetSize     int64
+	decoupleActual bool
 }
 
 // NewNodeGroup creates a new mock NodeGroup
 func NewNodeGroup(id string, name string, minSize int64, maxSize int64, targetSize int64) *NodeGroup {
 	return &NodeGroup{
-		id,
-		name,
-		minSize,
-		maxSize,
-		targetSize,
-		targetSize,
+		id:         id,
+		name:       name,
+		minSize:    minSize,
+		maxSize:    maxSize,
+		actualSize: targetSize,
+		targetSize: targetSize,
 	}
 }
 
@@ -166,11 +167,25 @@ func (n *NodeGroup) Nodes() []string {
 	return nil
 }
 
+// SetDecoupleActual configures whether IncreaseSize updates actualSize.
+// When true, actualSize must be updated explicitly via SetActualSize, simulating
+// an ASG that raises desired capacity but does not deliver running instances.
+func (n *NodeGroup) SetDecoupleActual(b bool) {
+	n.decoupleActual = b
+}
+
+// SetActualSize sets the running instance count independently of targetSize.
+func (n *NodeGroup) SetActualSize(size int64) {
+	n.actualSize = size
+}
+
 // setDesiredSize mock implementation for NodeGroup
 func (n *NodeGroup) setDesiredSize(newSize int64) error {
 	// This is where we would tell the actual provider (AWS etc.) to change the scaling group desired size
 	// but we just update the internal target size of the node group to reflect the remote change
 	n.targetSize = newSize
-	n.actualSize = newSize
+	if !n.decoupleActual {
+		n.actualSize = newSize
+	}
 	return nil
 }


### PR DESCRIPTION
## Problem

When an ASG can't fulfil a desired-count increase, because an instance type is temporarily out of capacity in an AZ, no instances launch but pod utilisation stays high. Escalator keeps raising the desired count every scan, so it climbs to `max_nodes` while the running count stays flat, leaving a large and persistent gap between desired and running.

We hit this in production. An ASG sat at desired 600 against an AZ with no capacity, running stayed near 100, and we reset the desired count by hand.

## What this does

An opt-in, per-nodegroup circuit breaker that stops raising the ASG desired count once repeated scale-ups fail to add running nodes. Disabled by default.

- A scale-up is counted as failed when the running count has not grown since the previous scale-up, meaning the cloud provider delivered no new capacity in the interim. Judging on "did running grow" rather than "did running reach the previous target" keeps a busy-but-healthy group, whose desired count rises faster than instances launch, from tripping.
- After `scale_up_failure_threshold` consecutive failures the breaker opens and stops raising the desired count, holding it steady rather than ratcheting it up further.
- There is no cooldown timer. Escalator keeps looping as normal while the breaker is open. It closes and normal scaling resumes as soon as the running count catches up to the current desired count, meaning the cloud provider finally delivered the capacity. The recovery check reads the current desired count, not a value frozen at trip time, so if desired is lowered externally while open, by a scale-down as demand falls or a manual reset, the breaker still recovers rather than staying stuck.
- Untaint of existing nodes is not gated, so already-running capacity is still reused during a crunch.

The gate sits only around the desired-count increase in `scaleUpCloudProviderNodeGroup`. Note that "running count" here is the ASG instance count (`Size()`), not the number of Ready Kubernetes nodes. This targets the out of capacity case where no instances launch at all. If instances launch but never join, for example a broken bootstrap, the count grows and the breaker reads that as capacity arriving, so it will not trip on that failure mode.

## Worked example

Node group with `max_nodes: 600`, running 100, `scale_up_cool_down_period: 5m`, each loop wanting roughly +50 nodes to clear a backlog of pending pods. An instance type is out of capacity in the AZ, so nothing launches and running stays at 100. Breaker set to `scale_up_failure_threshold: 3`.

| Time | Desired (breaker disabled) | Desired (breaker enabled) | Running |
|------|----------------------------|---------------------------|---------|
| 00:00 | 150 | 150 | 100 |
| 05:00 | 200 | 200 (failure 1, running didn't grow) | 100 |
| 10:00 | 250 | 250 (failure 2) | 100 |
| 15:00 | 300 | 250 (opens on failure 3, desired held) | 100 |
| 25:00 | 400 | 250 (held) | 100 |
| 45:00 | 600 (max) | 250 (held) | 100 |
| AZ recovers | 600 (500-node overshoot) | 250 delivered, breaker closes | 250 |

With the breaker disabled the desired count climbs to the max of 600 while only 100 nodes run, a gap of 500 nodes that all try to launch at once when the AZ recovers and overshoot real demand. With the breaker it caps at 250 and holds there, with no cooldown to wait out. When the AZ recovers, the 250 requested nodes launch, the running count catches up to the held desired count of 250, the breaker closes, and scaling resumes against real demand.

## Configuration

The default `scale_up_failure_threshold` of 0 disables the breaker, so existing configs are unchanged.

```yaml
scale_up_failure_threshold: 5
```

Judging on whether the running count grows means a group that launches instances steadily, even slowly, keeps making progress and does not accrue failures, so slow launch latency does not by itself trip the breaker.

## Metrics

- `node_group_scale_up_circuit_breaker_open`, a gauge that is 1 when open and 0 when closed. It is seeded to 0 when an enabled breaker is built, so an enabled group that never trips still emits a baseline.
- `node_group_scale_up_failed_scale_events`, a counter of scale-ups whose running count did not grow.

## Verification

`go test ./pkg/...` passes. Unit tests cover the state machine: disabled, reset when running grows, no trip on a healthy group whose desired count keeps rising while running climbs, trip after threshold consecutive no-growth scale-ups, stays open until running reaches desired, recovery once running catches up, recovery when desired is lowered externally while open, and failed-event counting. An integration test runs `scaleUpCloudProviderNodeGroup` against a mock ASG that raises the desired count but never delivers nodes, asserts the desired count freezes once the breaker trips, and then that scaling resumes once the running count reaches the frozen target.
